### PR TITLE
Fix crashing test by forcing pytorch cpu version

### DIFF
--- a/causallib/contrib/requirements.txt
+++ b/causallib/contrib/requirements.txt
@@ -1,2 +1,2 @@
--f https://download.pytorch.org/whl/torch_stable.html  # To support torch installation
-torch>=1.2.0+cpu
+-f https://download.pytorch.org/whl/cpu/  # To support cpu torch installation
+torch>=1.2.0


### PR DESCRIPTION
[Previous Travis builds](https://travis-ci.com/github/IBM/causallib/builds/223732072) crash when running HEMM pytorch-based tests.
This does not happen locally or in other private Travis builds. 
It seems a possible culprit is Travis installing a beta Pytorch ROCm version, ignoring the `+cpu` suffix (which does not seem to work with the `>=` version specifier). 

Current suggested solution is to point pip to a [cpu-specific repository on pytorch.org](https://download.pytorch.org/whl/cpu/torch/). 