### PR TITLE
Fix Travis failing due to numpy-pandas version mismatch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,12 @@ before_script:
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
 install:
+  - pip install --upgrade pip
   - pip install -r requirements.txt
   - pip install -r causallib/contrib/requirements.txt
   - pip install --upgrade pytest pytest-cov
 script:
+  - pip install --upgrade pip
   - pip install -e .  # test that install is running properly
   - pip install -e .[contrib]  # test optional install
   - pip freeze

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pandas>=0.21,<2
-scipy>=0.19,<1.5
+scipy>=0.19,<2
 statsmodels>=0.8,<1
 networkx>=1.1,<3
 numpy>=1.13,<2


### PR DESCRIPTION
[Previous Travis jobs[(https://travis-ci.com/github/IBM/causallib/builds/230977302) failed for python 3.7 because pip used an older numpy version (1.16.4) incompatible with newer pandas versions (1.2.x).
Problem seemed to be from either Scipy upper limit version limiting numpy or old pip version on Travis using a poor version-resolver.
Removing Scipy upper bound and forcing Travis to upgrade its pip version before installing requirements seem to solve the problem. 