### PR TITLE
Confounder selection module

### DIFF
--- a/causallib/contrib/shared_sparsity_selection/__init__.py
+++ b/causallib/contrib/shared_sparsity_selection/__init__.py
@@ -1,0 +1,1 @@
+from .shared_sparsity_selection import SharedSparsityConfounderSelection

--- a/causallib/contrib/shared_sparsity_selection/shared_sparsity_selection.py
+++ b/causallib/contrib/shared_sparsity_selection/shared_sparsity_selection.py
@@ -1,0 +1,176 @@
+# Implements Shared Sparsity Confounder Selection suggested by:
+# https://arxiv.org/abs/2011.01979
+
+import warnings
+import numpy as np
+from sklearn.exceptions import ConvergenceWarning
+from causallib.preprocessing.confounder_selection import _BaseConfounderSelection
+
+__all__ = ["SharedSparsityConfounderSelection"]
+
+
+class MCPSelector:
+    # TODO: transpose `theta` and rename it `coef_` to align with sklearn models
+    def __init__(self, lmda="auto", alpha=1, step=0.1, max_iter=1000, tol=1e-3):
+        """Constructor for MCPSelector. This class computes shared
+        sparsity matrix using proximal gradient descent applied with
+        MCP regularizer.
+
+        Args:
+            lmda (str|float): Parameter (>= 0) to control shape of MCP regularizer.
+                The bigger the value the stronger the regularization.
+                "auto" will auto-select good regularization value.
+            alpha (float): Associated lambda parameter (>= 0) to control shape of MCP regularizer.
+                The smaller the value the stronger the regularization.
+            step (float): Step size for proximal gradient, equivalent of learning rate.
+            max_iter (int): Maximum number of iterations of MCP proximal gradient.
+            tol (float): Stopping criterion for MCP. If the normalized value of
+                proximal gradient is less than tol then the algorithm is assumed
+                to have converged.
+        """
+        super().__init__()
+        self.alpha = alpha
+        self.lmda = lmda
+        self.step = step
+        self.max_iter = max_iter
+        self.tol = tol
+        self.epsilon_safe_division = 1e-6
+
+    def _initialize_internal_params(self, X, a, y):
+        treatments = list(a.unique())
+        n_treatments = len(treatments)
+        n_confounders = X.shape[1]
+        if self.lmda == "auto":
+            avg_num_samples = len(y) / n_treatments
+            lmda = 0.2 * np.sqrt(n_treatments * np.log(n_confounders) / avg_num_samples)
+        else:
+            lmda = self.lmda
+
+        assert self.alpha >= 0
+        assert lmda >= 0
+
+        corr_xx = np.zeros((n_confounders, n_confounders, n_treatments))
+        corr_xa = np.zeros((n_confounders, n_treatments))
+        for i, t in enumerate(treatments):
+            u, v = X.loc[a == t].values.T, y.loc[a == t].values
+            corr_xx[:, :, i] = (u @ u.T) / len(v)
+            corr_xa[:, i] = (u @ v) / len(v)
+        self.theta_ = np.zeros((n_confounders, n_treatments))
+        self.corr_mats_ = {"corr_xx": corr_xx, "corr_xa": corr_xa}  # Correlation matrices
+        self.n_confounders_ = n_confounders
+        self.n_treatments_ = n_treatments
+        self.lmda_ = lmda
+
+    def _mcp_q_grad(self, t):
+        if self.alpha == 0:
+            return np.sign(t) * self.lmda_ * (-1)
+        else:
+            return (np.sign(t) * self.lmda_
+                    * np.maximum(-1, - np.abs(t) / (self.lmda_ * self.alpha)))
+
+    def _update_grad_op(self, theta):
+        theta_new = np.zeros_like(theta)
+        for j in range(self.n_treatments_):
+            sub = (self.corr_mats_["corr_xx"][:, :, j] @ theta[:, j]
+                   - self.corr_mats_["corr_xa"][:, j])
+            theta_new[:, j] = theta[:, j] - self.step * sub
+        norm_matrix = (np.linalg.norm(theta, axis=1, keepdims=True)
+                       @ np.ones((1, self.n_treatments_)))
+        eps = self.epsilon_safe_division
+        theta_grad_op = theta_new - (self.step * (self._mcp_q_grad(norm_matrix))
+                                     * theta / (norm_matrix + eps))
+        return theta_grad_op
+
+    def _update_proximal_op(self, theta):
+        norm_theta = np.linalg.norm(theta, axis=1, keepdims=True)
+        shrink = np.maximum(0, norm_theta - self.lmda_)
+        theta_proximal_op = theta * ((shrink / norm_theta)
+                                     @ np.ones((1, self.n_treatments_)))
+        return theta_proximal_op
+
+    def compute_shared_sparsity_matrix(self, X, a, y):
+        self._initialize_internal_params(X, a, y)
+        theta = self.theta_
+        for i in range(self.max_iter):
+            theta_prev = theta
+            theta_grad_op = self._update_grad_op(theta_prev)
+            theta = self._update_proximal_op(theta_grad_op)
+
+            convergence_criteria = (
+                    np.linalg.norm(theta - theta_prev) /
+                    (np.linalg.norm(theta) + self.epsilon_safe_division)
+            )
+            has_converged = convergence_criteria <= self.tol
+            if has_converged:
+                break
+        else:
+            warnings.warn("Shared sparsity did not converge in maximum iterations.", ConvergenceWarning)
+        self.theta_ = theta
+        return self.theta_
+
+
+class SharedSparsityConfounderSelection(_BaseConfounderSelection):
+    """Class to select confounders by first applying shared sparsity method.
+    Method by Greenewald, Katz-Rogozhnikov, and Shanmugam: https://arxiv.org/abs/2011.01979
+    """
+
+    def __init__(self, mcp_lambda="auto", mcp_alpha=1, step=0.1, max_iter=1000, tol=1e-3, threshold=1e-6,
+                 importance_getter=None, covariates=None):
+        """Constructor for SharedSparsityConfounderSelection
+
+        Args:
+            mcp_lambda (str|float): Parameter (>= 0) to control shape of MCP regularizer.
+                The bigger the value the stronger the regularization.
+                "auto" will auto-select good regularization value.
+            mcp_alpha (float): Associated lambda parameter (>= 0) to control shape of MCP regularizer.
+                The smaller the value the stronger the regularization.
+            step (float): Step size for proximal gradient, equivalent of learning rate.
+            max_iter (int): Maximum number of iterations of MCP proximal gradient.
+            tol (float): Stopping criterion for MCP. If the normalized value of
+                proximal gradient is less than tol then the algorithm is assumed
+                to have converged.
+            threshold (float): Only if the importance of a confounder exceeds
+                threshold for all values of treatments, then the confounder
+                is retained by transform() call.
+            importance_getter: IGNORED.
+            covariates (list | np.ndarray): Specifying a subset of columns to perform selection on.
+                Columns in `X` but not in `covariates` will be included after `transform`
+                no matter the selection.
+                Can be either a list of column names, or an array of boolean indicators length of `X`,
+                or anything compatible with pandas `loc` function for columns.
+                if `None` then all columns are participating in the selection process.
+                This is similar to using sklearn's `ColumnTransformer` or `make_column_selector`.
+        """
+        super().__init__(importance_getter=importance_getter, covariates=covariates)
+        self.step = step
+        self.max_iter = max_iter
+        self.tol = tol
+        self.threshold = threshold
+        self.selector_ = MCPSelector(lmda=mcp_lambda, alpha=mcp_alpha, step=step, max_iter=max_iter, tol=tol)
+
+        self.importance_getter = lambda e: e.selector_.theta_.transpose()  # Shape to behave like sklearn linear_model
+        # self.importance_getter = "selector_.theta_"
+
+    @_BaseConfounderSelection._filter_covariates
+    def fit(self, X, a, y):
+        # compute_shared_sparsity_matrix() below should return
+        # a matrix of shape (n_confounders x n_treatments).
+        # The confounders to be retained in transform() corresponds to those rows
+        # which have significant values across all the columns.
+        theta = self.selector_.compute_shared_sparsity_matrix(X, a, y)
+        support = (np.abs(theta) >= self.threshold).all(axis=1)
+        if not support.any():
+            warnings.warn("Shared sparsity selected zero features. Ignoring and selecting all features.")
+            self.support_ = np.ones(X.shape[1], dtype=bool)
+        else:
+            self.support_ = support
+        self.n_features_ = sum(self.support_)
+        return self
+
+    # @_BaseConfounderSelection._filter_and_re_add_covariates
+    # def transform(self, X, a=None):
+    #     X = X.loc[:, self.get_support()]
+    #     return X
+
+    def _get_support_mask(self):
+        return self.support_

--- a/causallib/contrib/tests/test_shared_sparsity_selection.py
+++ b/causallib/contrib/tests/test_shared_sparsity_selection.py
@@ -1,0 +1,151 @@
+import numpy as np
+import pandas as pd
+from sklearn.datasets import make_classification
+from sklearn.preprocessing import StandardScaler
+from sklearn.exceptions import ConvergenceWarning
+
+from causallib.contrib.shared_sparsity_selection import SharedSparsityConfounderSelection
+from causallib.tests.test_confounder_selection import _TestConfounderSelection
+
+
+class TestSharedSparsitySelection(_TestConfounderSelection):
+
+    def make_xay(self, n_confounders_a, n_max_confounders_y, n_samples, xay_cols=10, seed=None):
+        # rng = np.random.default_rng(seed)
+        if seed:
+            np.random.seed(seed)
+        X, a = make_classification(
+            n_samples=n_samples,
+            n_features=xay_cols + 1,
+            n_informative=int(min(n_confounders_a, xay_cols)),
+            n_redundant=0, n_repeated=0, class_sep=10.0,
+            n_clusters_per_class=1,
+            shuffle=False,  # random_state=seed
+        )
+        y_confounder_indicator = np.zeros(X.shape[1], dtype=bool)
+        y_confounder_indicator[:int(min(n_max_confounders_y, xay_cols))] = 1
+        np.random.shuffle(y_confounder_indicator)
+        y = X[:, y_confounder_indicator] @ np.random.normal(size=y_confounder_indicator.sum())
+
+        X = StandardScaler().fit_transform(X)
+        X = pd.DataFrame(X, columns=["x_" + str(i) for i in range(X.shape[1])])
+        a = pd.Series(a)
+        y = pd.Series(y)
+        return X, a, y
+
+    def test_covariate_subset(self):
+        X, a, y = self.make_xay(6, 4, n_samples=100, seed=1)
+        true_subset_confounders = ['x_0', 'x_2']  # Matches random seed: 6
+        covariates_subset = ['x_0', 'x_2', f'x_{X.shape[1] - 1}', f'x_{X.shape[1] - 3}']
+
+        sss = SharedSparsityConfounderSelection(covariates=covariates_subset)
+        sss = self.ensure_covariate_subset(sss, X, a, y, true_subset_confounders)
+
+        np.testing.assert_array_equal(covariates_subset, sss.covariates)
+        self.assertEqual(len(covariates_subset), sss.selector_.theta_.shape[0])
+        self.assertEqual(2, sss.selector_.theta_.shape[1])  # Two treatments
+        self.assertEqual(len(true_subset_confounders), np.sum(np.abs(sss.selector_.theta_[:, 0]) > 0))
+        self.assertEqual(len(true_subset_confounders), np.sum(np.abs(sss.selector_.theta_[:, 1]) > 0))
+
+    def test_covariate_subset_binary(self):
+        X, a, y = self.make_xay(6, 4, n_samples=100, seed=1)
+        true_subset_confounders = ['x_0', 'x_2']  # Matches random seed: 6
+        covariates_subset = ['x_0', 'x_2', f'x_{X.shape[1] - 1}', f'x_{X.shape[1] - 3}']
+        # Convert to binary:
+        true_subset_confounders = X.columns.isin(true_subset_confounders)
+        covariates_subset = X.columns.isin(covariates_subset)
+
+        sss = SharedSparsityConfounderSelection(covariates=covariates_subset)
+        sss = self.ensure_covariate_subset_binary(sss, X, a, y, true_subset_confounders)
+
+        np.testing.assert_array_equal(covariates_subset, sss.covariates)
+        self.assertEqual(covariates_subset.sum(), sss.selector_.theta_.shape[0])
+        self.assertEqual(2, sss.selector_.theta_.shape[1])  # Two treatments
+        self.assertEqual(sum(true_subset_confounders), np.sum(np.abs(sss.selector_.theta_[:, 0]) > 0))
+        self.assertEqual(sum(true_subset_confounders), np.sum(np.abs(sss.selector_.theta_[:, 1]) > 0))
+
+    def test_alphas(self):
+        X, a, y = self.make_xay(6, 4, n_samples=100, seed=1)
+        alphas = [0, 1]
+        for alpha in alphas:
+            sss = SharedSparsityConfounderSelection(mcp_alpha=alpha)
+            sss.fit(X, a, y)
+            Xt = sss.transform(X)
+            self.assertSetEqual(set(Xt.columns), {'x_0', 'x_2'})
+
+        with self.assertRaises(AssertionError):
+            sss = SharedSparsityConfounderSelection(mcp_alpha=-1)
+            sss.fit(X, a, y)
+
+        with self.subTest("shrinkage"):
+            strong = SharedSparsityConfounderSelection(mcp_alpha=0.1).fit(X, a, y).selector_.theta_
+            weak = SharedSparsityConfounderSelection(mcp_alpha=100).fit(X, a, y).selector_.theta_
+            self.assertLess(np.linalg.norm(strong), np.linalg.norm(weak))
+
+    def test_lambdas(self):
+        X, a, y = self.make_xay(6, 4, n_samples=100, seed=1)
+
+        with self.subTest("Automatic (default) lambda"):
+            sss = SharedSparsityConfounderSelection(mcp_lambda="auto")
+            sss.fit(X, a, y)
+            expected = 0.2 * np.sqrt(2 * np.log(X.shape[1]) / (X.shape[0] / 2))
+            self.assertAlmostEqual(sss.selector_.lmda_, expected)
+
+        with self.subTest("Pre-specified lambda"):
+            lmda = 2.1
+            sss = SharedSparsityConfounderSelection(mcp_lambda=lmda)
+            sss.fit(X, a, y)
+            self.assertEqual(sss.selector_.lmda_, lmda)
+
+        with self.subTest("Illegal lambda"):
+            with self.assertRaises(AssertionError):
+                sss = SharedSparsityConfounderSelection(mcp_lambda=-1)
+                sss.fit(X, a, y)
+
+        with self.subTest("shrinkage"):
+            weak = SharedSparsityConfounderSelection(mcp_lambda=0.1).fit(X, a, y).selector_.theta_
+            strong = SharedSparsityConfounderSelection(mcp_lambda=1).fit(X, a, y).selector_.theta_
+            self.assertLess(np.linalg.norm(strong), np.linalg.norm(weak))
+
+    def test_max_iter(self):
+        X, a, y = self.make_xay(6, 4, n_samples=100, seed=1)
+
+        with self.subTest("Force convergence warning"):
+            sss = SharedSparsityConfounderSelection(max_iter=2)
+            with self.assertWarns(ConvergenceWarning):
+                sss.fit(X, a, y)
+
+        # with self.subTest("Convergence happens in less than max_iter"):
+        #     import timeit
+        #     n_repeats = 50
+        #     times = []
+        #     for max_iter in [10000, 100000]:
+        #         # Algorithm will converge long before exceeding `max_iter` and so time should remain similar
+        #         sss = SharedSparsityConfounderSelection(max_iter=max_iter)
+        #         avg_time = timeit.timeit(lambda: sss.fit(X, a, y), number=n_repeats)
+        #         times.append(avg_time)
+        #     self.assertAlmostEqual(times[0], times[1], places=1)
+
+    def test_final_selection(self):
+        """Test against current implementation to allow for refactoring"""
+        X, a, y = self.make_xay(6, 4, n_samples=100, seed=1)
+        sss = SharedSparsityConfounderSelection()
+        sss.fit(X, a, y)
+        Xt = sss.transform(X)
+        self.assertSetEqual(set(Xt.columns), {'x_0', 'x_2'})
+
+    def test_importance_getter(self):
+        from causallib.preprocessing.confounder_selection import _get_feature_importances
+
+        X, a, y = self.make_xay(2, 2, xay_cols=2, n_samples=100, seed=1)
+        sss = SharedSparsityConfounderSelection()
+        sss.fit(X, a, y)
+
+        importance = _get_feature_importances(sss, sss.importance_getter)
+        expected = np.array([[0.0, 0.0],
+                             [5.86299046, 5.94375083],
+                             [0.0, 0.0]
+                             ])
+        np.testing.assert_array_almost_equal(expected.transpose(), importance)
+        np.testing.assert_array_almost_equal(sss.selector_.theta_.transpose(), importance)
+

--- a/causallib/preprocessing/confounder_selection.py
+++ b/causallib/preprocessing/confounder_selection.py
@@ -1,0 +1,284 @@
+import numpy as np
+from sklearn.base import BaseEstimator, MetaEstimatorMixin, clone
+from sklearn.utils.multiclass import type_of_target
+from sklearn.linear_model import LassoCV, LogisticRegressionCV
+# Find internal implementations
+try:  # Version 0.20 - 0.21
+    from sklearn.feature_selection.base import SelectorMixin
+except ModuleNotFoundError:
+    # Version >= 0.22
+    from sklearn.feature_selection._base import SelectorMixin
+
+
+__all__ = ["DoubleLASSO", "RecursiveConfounderElimination"]
+
+
+# noinspection PyAbstractClass
+class _BaseConfounderSelection(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
+    def __init__(self, importance_getter='auto', covariates=None):
+        self.importance_getter = importance_getter
+        self.covariates = covariates
+
+    # TODO: move functionality for general utils and use for Estimators as well
+    @staticmethod
+    def _filter_covariates(func):
+        def filter_covariates_and_run(self, X, *args, **kwargs):
+            covariates = self.covariates
+            if covariates is None:
+                covariates = X.columns
+            X = X.loc[:, covariates]
+            return func(self, X, *args, **kwargs)
+        return filter_covariates_and_run
+
+    # @staticmethod
+    def _filter_and_re_add_covariates(func):
+        def filter_covariates_and_run_and_add(self, X, *args, **kwargs):
+            covariates = self.covariates
+            if covariates is None:
+                covariates = X.columns
+            sub_X = X.loc[:, covariates]
+            res = func(self, sub_X, *args, **kwargs)
+            complement_covariates = X.columns.difference(sub_X.columns)
+            res = res.join(X.loc[:, complement_covariates])
+            return res
+        return filter_covariates_and_run_and_add
+
+    @_filter_and_re_add_covariates
+    def transform(self, X, a=None):
+        X = X.loc[:, self.get_support()]
+        return X
+
+    # Decorator function cannot be defined as static before decorating,
+    # so setting as the decorator as `staticmethod` is done after defining the `transform` using the decorator
+    _filter_and_re_add_covariates = staticmethod(_filter_and_re_add_covariates)
+
+
+class DoubleLASSO(_BaseConfounderSelection):
+    def __init__(self, treatment_lasso=None, outcome_lasso=None,
+                 mask_fn=None, threshold=1e-6,
+                 importance_getter='auto', covariates=None):
+        """
+        A method for selecting confounders using sparse regression
+        on both the treatment and the outcomes, and select for
+
+        Implementing "Inference on Treatment Effects after Selection
+        among High-Dimensional Controls"
+        https://academic.oup.com/restud/article/81/2/608/1523757
+
+        Args:
+            treatment_lasso: Lasso learner to fit confounders and treatment.
+                For example using scikit-learn,
+                continuous treatment may use: `Lasso()`,
+                discrete treatment may use: `LogisticRegression(penalty='l1')`.
+                If `None` will try to automatically assign a lasso model with cross validation.
+            outcome_lasso: Lasso learner to fit confounders and outcome.
+                For example using scikit-learn,
+                continuous outcome may use: `Lasso()`,
+                discrete outcome may use: `LogisticRegression(penalty='l1')`.
+                If `None` will try to automatically assign lasso model cross-validation.
+            mask_fn: Function that takes input as two fitted lasso learners
+                and returns a mask of the length of number of columns where True
+                corresponds to columns that need to be selected. When set to None,
+                the default implementation returns a mask based on non-zero
+                coefficients in either learner. User can supply their own function,
+                which must return a boolean array (of the length of columns of X)
+                to indicate which columns are to be included.
+            threshold: For default mask_fn, absolute value below which a lasso
+                coefficient is treated as zero.
+            importance_getter (str | callable): how to obtain feature importance.
+                either a callable that inputs an estimator,
+                a string of `'coef_'` or `'feature_importance_'`,
+                or `'auto'` will detect `'coef_'` or `'feature_importance_'` automatically.
+            covariates (list | np.ndarray): Specifying a subset of columns to perform selection on.
+                Columns in `X` but not in `covariates` will be included after `transform`
+                no matter the selection.
+                Can be either a list of column names, or an array of boolean indicators length of `X`,
+                or anything compatible with pandas `loc` function for columns.
+                if `None` then all columns are participating in the selection process.
+                This is similar to using sklearn's `ColumnTransformer` or `make_column_selector`.
+        """
+        # TODO: allowing users to provide the models follows the same design
+        #       design principle throughout causallib,
+        #       however, this might put some strain on the users who will need
+        #       to know to supply `sklearn.linear_model.LogisticRegression(penalty='l1')
+        #       for the treatment and the same for categorical outcome, but
+        #       `sklearn.linear_model.Lasso` for continuous outcome.
+        super().__init__(importance_getter, covariates)
+        self.treatment_lasso = treatment_lasso
+        self.outcome_lasso = outcome_lasso
+        self.mask_fn = mask_fn
+        self.threshold = threshold
+
+    @_BaseConfounderSelection._filter_covariates
+    def fit(self, X, a, y):
+        self.treatment_lasso = self._data_driven_initialization(self.treatment_lasso, a)
+        self.outcome_lasso = self._data_driven_initialization(self.outcome_lasso, y)
+
+        self.treatment_lasso.fit(X, a)
+        self.outcome_lasso.fit(X, y)
+        mask_fn = self.mask_fn or self._get_non_zero_coef_mask
+        self.support_ = mask_fn(self.treatment_lasso, self.outcome_lasso)
+        self.n_features_ = self.support_.sum()
+        return self
+
+    # @_BaseConfounderSelection._filter_and_re_add_covariates
+    # def transform(self, X, a=None):
+    #     X = X.iloc[:, self.get_support()]
+    #     return X
+
+    def _get_support_mask(self):
+        return self.support_
+
+    def _get_non_zero_coef_mask(self, treatment_lasso, outcome_lasso):
+        # Using _get_feature_importances from sklearn covers many more
+        # edge cases than writing a vanilla function.
+        # Specifying transform_func "norm" in the call below
+        # actually calls np.abs when the coef_ attribute of treatment_lasso
+        # (or output_lasso) is a one dimensional vector.
+        treatment_lasso_importances = _get_feature_importances(
+            treatment_lasso, self.importance_getter, transform_func="norm",
+        )
+        outcome_lasso_importances = _get_feature_importances(
+            outcome_lasso, self.importance_getter, transform_func="norm",
+        )
+        treatment_mask = treatment_lasso_importances >= self.threshold
+        outcome_mask = outcome_lasso_importances >= self.threshold
+        return treatment_mask | outcome_mask
+
+    @staticmethod
+    def _data_driven_initialization(estimator, target):
+        if estimator is not None:  # User provided an estimator
+            return estimator
+
+        if type_of_target(target) == "continuous":
+            estimator = LassoCV()
+        else:
+            estimator = LogisticRegressionCV(penalty='l1', solver='saga', max_iter=5000)
+        return estimator
+
+
+class RecursiveConfounderElimination(_BaseConfounderSelection):
+
+    def __init__(self, estimator, n_features_to_select: int = 1, step: int = 1,
+                 importance_getter="auto", covariates=None):
+        """Recursively eliminate confounders to prune confounders.
+
+        Args:
+            estimator: Estimator to fit for every step of recursive elimination.
+            n_features_to_select (int): The number of confounders to keep.
+            step (int): The number of confounders to eliminate in one iteration.
+            importance_getter (str | callable): how to obtain feature importance.
+              either a callable that inputs an estimator,
+              a string of `'coef_'` or `'feature_importance_'`,
+              or `'auto'` will detect `'coef_'` or `'feature_importance_'` automatically.
+            covariates (list | np.ndarray): Specifying a subset of columns to perform selection on.
+              Columns in `X` but not in `covariates` will be included after `transform`
+              no matter the selection.
+              Can be either a list of column names, or an array of boolean indicators length of `X`,
+              or anything compatible with pandas `loc` function for columns.
+              if `None` then all columns are participating in the selection process.
+              This is similar to using sklearn's `ColumnTransformer` or `make_column_selector`.
+        """
+        super().__init__(importance_getter, covariates)
+        self.estimator = estimator
+        self.n_features_to_select = n_features_to_select
+        self.step = step
+
+    @_BaseConfounderSelection._filter_covariates
+    def fit(self, X, a, y):
+        # This is like an abbreviated implementation of RFE in sklearn.
+        # Main differences are (a) Conditioning on treatment for every iteration,
+        # (b) adjusting ranking/support not to include treatment, and (c) accounting
+        # for causallib data types for X and a.
+        # TODO: the entire implementation may be reduced to overwriting the
+        #       `importance_getter` function and rigging it to have infinity
+        #       importance for the treatment assignment every time.
+        n_features = len(X.columns)
+        support_ = np.ones(n_features, dtype=bool)
+        ranking_ = np.ones(n_features, dtype=int)
+        while np.sum(support_) > self.n_features_to_select:
+            features = np.arange(n_features)[support_]
+            estimator = clone(self.estimator)
+            estimator.fit(a.to_frame().join(X.iloc[:, features]), y)
+            importances = _get_feature_importances(
+                estimator, self.importance_getter, transform_func="square",
+            )
+            importances = importances[1:]  # Do not consider "a" for dropping
+            ranks = np.argsort(importances)
+            ranks = np.ravel(ranks)
+            threshold = min(self.step, np.sum(support_) - self.n_features_to_select)
+            support_[features[ranks][:threshold]] = False
+            ranking_[np.logical_not(support_)] += 1
+        features = np.arange(n_features)[support_]
+        self.estimator.fit(a.to_frame().join(X.iloc[:, features]), y)
+        self.n_features_ = support_.sum()
+        self.support_ = support_
+        self.ranking_ = ranking_
+        return self
+
+    # @_BaseConfounderSelection._filter_and_re_add_covariates
+    # def transform(self, X, a=None):
+    #     X = X.iloc[:, self.get_support()]
+    #     return X
+
+    def _get_support_mask(self):
+        return self.support_
+
+
+def _get_feature_importances(estimator, getter, transform_func=None, norm_order=1):
+    """
+    Retrieve and aggregate (if ndim > 1) (and optionally transforms)
+    the feature importances from an estimator.
+
+    Args:
+        estimator: A scikit-learn estimator from which we want to get the feature importances.
+        getter (str | callable):  An attribute or a callable to get the feature importance.
+                If `"auto"`, `estimator` is expected to expose `coef_` or `feature_importances_`.
+        transform_func (str | None): The transform to apply to the feature importances.
+                By default (`None`) no transformation is applied.
+                Only "norm" and "square" are currently supported.
+        norm_order (int): The norm order to apply when `transform_func="norm"`.
+                Only applied when `importances.ndim > 1`.
+
+    Returns:
+        np.ndarray: The features importances, optionally transformed.
+    """
+    # A local version of sklearn's `_get_feature_importance`,
+    # Because there have been multiple changes between version 0.20 and 0.24
+    # in both API and import location, it uses the 0.24 version of the function.
+    # Once dependencies move to > 0.24 this may be removed
+
+    if isinstance(getter, str):
+        if getter == "auto":
+            if hasattr(estimator, "coef_"):
+                getter = "coef_"
+            elif hasattr(estimator, "feature_importances_"):
+                getter = "feature_importances_"
+            else:
+                raise ValueError(
+                    f"`importance_getter=='auto'` requires the estimator to have "
+                    f"a `coef_` or `feature_importances_` attribute. "
+                    f"If your estimator should have these attributes, "
+                    f"make sure it is fitted before calling transform."
+                )
+        importances = getattr(estimator, getter)
+    elif callable(getter):
+        importances = getter(estimator)
+    else:
+        raise ValueError("`importance_getter` has to be a string or `callable`")
+
+    if transform_func is None:
+        pass
+    elif transform_func == "norm":
+        if importances.ndim == 1:
+            importances = np.abs(importances)
+        else:
+            importances = np.linalg.norm(importances, axis=0, ord=norm_order)
+    elif transform_func == "square":
+        importances = importances ** 2
+        if importances.ndim > 1:
+            importances = importances.sum(axis=0)
+    else:
+        raise ValueError("`transform_func` only supports None, 'norm' and 'square'.")
+
+    return importances

--- a/causallib/tests/test_confounder_selection.py
+++ b/causallib/tests/test_confounder_selection.py
@@ -1,0 +1,374 @@
+"""
+(C) Copyright 2019 IBM Corp.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Created on Jul 22, 2018
+
+"""
+
+import unittest
+import random
+import pandas as pd
+import numpy as np
+from sklearn.linear_model import LogisticRegression
+from sklearn.datasets import make_classification
+from sklearn.preprocessing import StandardScaler
+from sklearn.utils.validation import check_is_fitted
+
+from causallib.preprocessing.confounder_selection import DoubleLASSO, RecursiveConfounderElimination
+
+
+class _TestConfounderSelection(unittest.TestCase):
+    def ensure_covariate_subset(self, selector, X, a, y, true_subset_confounders):
+        # covariates_subset = ['x_0', 'x_2', f'x_{X.shape[1] - 1}', f'x_{X.shape[1] - 3}']
+        covariates_subset = selector.covariates
+        covariates_subset = list(set(covariates_subset) | set(true_subset_confounders))  # Ensure true-covariate in set
+
+        selector.fit(X, a, y)
+        X_trans = selector.transform(X)
+        self.assertEqual(selector.n_features_, len(true_subset_confounders))
+        for element in true_subset_confounders:
+            self.assertIn(element, X_trans.columns)
+        for element in set(covariates_subset) - set(true_subset_confounders):
+            self.assertNotIn(element, X_trans.columns)
+        self.assertGreater(X_trans.columns.difference(covariates_subset).size, 0)
+        self.assertEqual(
+            X_trans.shape[1],
+            X.shape[1] - len(covariates_subset) + len(true_subset_confounders)
+        )
+        return selector
+
+    def ensure_covariate_subset_binary(self, selector, X, a, y, true_subset_confounders):
+        covariates_subset = selector.covariates | true_subset_confounders  # Ensure true-covariate in set
+
+        selector.fit(X, a, y)
+        X_trans = selector.transform(X)
+        self.assertEqual(selector.n_features_, true_subset_confounders.sum())
+        for element in X.columns[true_subset_confounders]:
+            self.assertIn(element, X_trans.columns)
+        for element in X.columns[covariates_subset].difference(X.columns[true_subset_confounders]):
+            self.assertNotIn(element, X_trans.columns)
+        self.assertGreater(X_trans.columns.difference(X.columns[covariates_subset]).size, 0)
+        self.assertEqual(
+            X_trans.shape[1],
+            X.shape[1] - covariates_subset.sum() + true_subset_confounders.sum()
+        )
+        return selector
+
+
+class TestDoubleLasso(_TestConfounderSelection):
+
+    def setUp(self):
+        # X is partitioned into two sets of xay_cols (parameter below)
+        # First set is related to a and second set is related to y.
+        # We generate each of this set using make_classification and
+        # then merge them.
+        self.xay_cols = 10
+        self.min_accuracy = 0.95
+
+    def make_xay(self, n_true_confounders_a, n_true_confounders_y, n_samples, seed=None):
+        if seed is None:
+            seed_a = random.randint(0, 2**16)
+            seed_y = random.randint(0, 2**16)
+        else:
+            seed_a = seed
+            seed_y = seed + 1
+        xa, a = make_classification(n_samples=n_samples,
+                                    n_features=self.xay_cols + 1,
+                                    n_informative=min(n_true_confounders_a, self.xay_cols),
+                                    n_redundant=0, n_repeated=0, class_sep=10.0,
+                                    n_clusters_per_class=1,
+                                    shuffle=False, random_state=seed_a)
+        xy, y = make_classification(n_samples=n_samples,
+                                    n_features=self.xay_cols + 1,
+                                    n_informative=min(n_true_confounders_y, self.xay_cols),
+                                    n_redundant=0, n_repeated=0, class_sep=10.0,
+                                    n_clusters_per_class=1,
+                                    shuffle=False, random_state=seed_y)
+        x = np.concatenate((xa, xy), axis=1)
+        x = StandardScaler().fit_transform(x)
+        xdf = pd.DataFrame(x, columns=["x_" + str(i) for i in range(x.shape[1])])
+        adf = pd.Series(a)
+        ydf = pd.Series(y)
+        return xdf, adf, ydf
+
+    @staticmethod
+    def make_simple_data():
+        data = [[1, 1, 1, 1, 0, 0] * 5,     # x1 column: same as a
+                [0, 0, 1, 0, 1, 1] * 5,     # x2 column: same as y
+                [1, 2, 1, 2, 1, 2] * 5,     # x3 column: unrelated
+                [1, 1, 1, 1, 0, 0] * 5,     # a (treatment)
+                [0, 0, 1, 0, 1, 1] * 5,     # y
+                ]
+        col_names = ['x1', 'x2', 'x3', 'a', 'y']
+        df = pd.DataFrame(list(zip(*data)), columns=col_names)
+        X, a, y = df[['x1', 'x2', 'x3']], pd.Series(df['a']), pd.Series(df['y'])
+        return X, a, y
+
+    def test_correct_recovery_simple_data(self):
+        X, a, y = self.make_simple_data()
+        treatment_lasso = LogisticRegression(penalty='l1', solver='saga', max_iter=5000)
+        outcome_lasso = LogisticRegression(penalty='l1', solver='saga', max_iter=5000)
+        d = DoubleLASSO(treatment_lasso=treatment_lasso,
+                        outcome_lasso=outcome_lasso,
+                        threshold=0.1)
+        d.fit(X, a, y)
+        result = d.transform(X)
+        treatment_cols = [X.columns[i] for i, c in enumerate(treatment_lasso.coef_.flatten())
+                          if abs(c) > 1e-4]
+        outcome_cols = [X.columns[i] for i, c in enumerate(outcome_lasso.coef_.flatten())
+                        if abs(c) > 1e-4]
+        self.assertEqual(len(treatment_cols), 1)
+        self.assertEqual(len(outcome_cols), 1)
+        self.assertListEqual(['x1', 'x2'], result.columns.tolist())
+
+    @staticmethod
+    def fit_transform(X, a, y, threshold=1e-6):
+        treatment_lasso = LogisticRegression(penalty='l1', solver='saga', max_iter=5000)
+        outcome_lasso = LogisticRegression(penalty='l1', solver='saga', max_iter=5000)
+        dl = DoubleLASSO(treatment_lasso, outcome_lasso, threshold=threshold)
+        dl.fit(X, a, y)
+        result = dl.transform(X)
+        score_a = treatment_lasso.score(X, a)
+        score_y = outcome_lasso.score(X, y)
+        return result, score_a, score_y
+
+    def run_config(self, n_true_confounders_a, n_true_confounders_y, n_samples=100, threshold=1e-6):
+        X, a, y = self.make_xay(n_true_confounders_a, n_true_confounders_y, n_samples)
+        result, score_a, score_y = self.fit_transform(X, a, y, threshold)
+        return result, score_a, score_y
+
+    def test_basic(self):
+        # Basic test by varying how many confounders are related to "a" and "y".
+        # We also check for accuracy of treatment_lasso and outcome_lasso with
+        # retained confounders as a proxy for how well we recover the confounders.
+        for i in range(10):
+            n_true_confounders_a = i + 1
+            n_true_confounders_y = i + 1
+            _, score_a, score_y = self.run_config(n_true_confounders_a, n_true_confounders_y)
+            self.assertGreaterEqual(score_a, self.min_accuracy)
+            self.assertGreaterEqual(score_y, self.min_accuracy)
+
+    def test_threshold(self):
+        # Vary zero-threshold and check that we select confounders as expected.
+        n_true_confounders_a = 5
+        n_true_confounders_y = 3
+        for threshold in np.logspace(-6, 2, 9):     # Vary threshold from 1e-6 to 100 in powers of 10
+            x, a, y = self.make_xay(n_true_confounders_a, n_true_confounders_y, n_samples=100)
+            treatment_lasso = LogisticRegression(penalty='l1', solver='saga', max_iter=5000)
+            outcome_lasso = LogisticRegression(penalty='l1', solver='saga', max_iter=5000)
+            dl = DoubleLASSO(treatment_lasso, outcome_lasso, threshold=threshold)
+            dl.fit(x, a, y)
+            expected = ((np.abs(treatment_lasso.coef_.flatten()) >= threshold)
+                        | (np.abs(outcome_lasso.coef_.flatten()) >= threshold))
+            np.testing.assert_array_equal(dl.support_, expected)
+
+    def test_mask_fn(self):
+
+        # Custom merge function 1: True whenever array index modulo 3 is 0.
+        def custom_mask_fn_and(tlasso, ylasso):
+            t_coef = np.array([True if j % 3 != 2 else False
+                               for j in range(len(tlasso.coef_.flatten()))], dtype=bool)
+            y_coef = np.array([True if j % 3 != 1 else False
+                               for j in range(len(ylasso.coef_.flatten()))], dtype=bool)
+            return np.logical_and(t_coef, y_coef)
+
+        # Custom merge function 2: True whenever array index modulo 3 is 0 or 1.
+        def custom_mask_fn_or(tlasso, ylasso):
+            t_coef = np.array([True if j % 3 == 0 else False
+                               for j in range(len(tlasso.coef_.flatten()))], dtype=bool)
+            y_coef = np.array([True if j % 3 == 1 else False
+                               for j in range(len(ylasso.coef_.flatten()))], dtype=bool)
+            return np.logical_or(t_coef, y_coef)
+
+        # Vary number of confounders. Supply custom merge function.
+        # Check at every step that the support_ attribute
+        # of the fitted DoubleLasso is the same as expected from custom merge function.
+        for i in range(10):
+            n_true_confounders_a = i + 1
+            n_true_confounders_y = i + 1
+            X, a, y = self.make_xay(n_true_confounders_a, n_true_confounders_y, n_samples=100)
+            treatment_lasso = LogisticRegression(penalty='l1', solver='saga', max_iter=5000)
+            outcome_lasso = LogisticRegression(penalty='l1', solver='saga', max_iter=5000)
+
+            dl = DoubleLASSO(treatment_lasso, outcome_lasso, mask_fn=custom_mask_fn_and)
+            dl.fit(X, a, y)
+            np.testing.assert_array_equal(
+                dl.support_, custom_mask_fn_and(treatment_lasso, outcome_lasso)
+            )
+
+            dl = DoubleLASSO(treatment_lasso, outcome_lasso, mask_fn=custom_mask_fn_or)
+            dl.fit(X, a, y)
+            np.testing.assert_array_equal(
+                dl.support_, custom_mask_fn_or(treatment_lasso, outcome_lasso)
+            )
+
+    def test_covariate_subset(self):
+        X, a, y = self.make_xay(2, 2, n_samples=100, seed=6)
+        true_subset_confounders = ['x_0']  # Matches random seed: 6
+        covariates_subset = ['x_0', 'x_2', f'x_{X.shape[1] - 1}', f'x_{X.shape[1] - 3}']
+
+        treatment_lasso = LogisticRegression(penalty='l1', solver='saga', max_iter=5000)
+        outcome_lasso = LogisticRegression(penalty='l1', solver='saga', max_iter=5000)
+        dl = DoubleLASSO(
+            treatment_lasso, outcome_lasso,
+            covariates=covariates_subset,
+        )
+
+        dl = self.ensure_covariate_subset(dl, X, a, y, true_subset_confounders)
+
+        np.testing.assert_array_equal(covariates_subset, dl.covariates)
+        self.assertEqual(len(covariates_subset), dl.treatment_lasso.coef_.shape[1])
+        self.assertEqual(len(covariates_subset), dl.outcome_lasso.coef_.shape[1])
+
+    def test_covariate_subset_binary(self):
+        X, a, y = self.make_xay(2, 2, n_samples=100, seed=6)
+        true_subset_confounders = ['x_0']  # Matches random seed: 6
+        covariates_subset = ['x_0', 'x_2', f'x_{X.shape[1] - 1}', f'x_{X.shape[1] - 3}']
+        # Convert to binary:
+        true_subset_confounders = X.columns.isin(true_subset_confounders)
+        covariates_subset = X.columns.isin(covariates_subset)
+
+        treatment_lasso = LogisticRegression(penalty='l1', solver='saga', max_iter=5000)
+        outcome_lasso = LogisticRegression(penalty='l1', solver='saga', max_iter=5000)
+        dl = DoubleLASSO(
+            treatment_lasso, outcome_lasso,
+            covariates=covariates_subset,
+        )
+
+        dl = self.ensure_covariate_subset_binary(dl, X, a, y, true_subset_confounders)
+
+        np.testing.assert_array_equal(covariates_subset, dl.covariates)
+        self.assertEqual(dl.covariates.sum(), dl.treatment_lasso.coef_.shape[1])
+        self.assertEqual(dl.covariates.sum(), dl.outcome_lasso.coef_.shape[1])
+
+    def test_auto_estimator_initialization(self):
+        from sklearn.linear_model import LogisticRegressionCV, LassoCV
+
+        X, a, y = self.make_xay(2, 2, n_samples=100, seed=6)
+        y += np.random.normal(size=y.shape)  # Make `y` continuous to check auto-target-detection
+        dl = DoubleLASSO()
+        dl.fit(X, a, y)
+
+        self.assertIsInstance(dl.treatment_lasso, LogisticRegressionCV)
+        self.assertIsInstance(dl.outcome_lasso, LassoCV)
+
+        self.assertIsNone(check_is_fitted(dl.treatment_lasso, "coef_"))
+        self.assertIsNone(check_is_fitted(dl.outcome_lasso, "coef_"))
+
+        self.assertEqual(dl.treatment_lasso.coef_.shape[1], X.shape[1])
+        self.assertEqual(dl.outcome_lasso.coef_.shape[0], X.shape[1])  # Lasso different shape than LogisticRegression
+
+
+class TestRecursiveConfounderElimination(_TestConfounderSelection):
+
+    def setUp(self):
+        self.max_x_cols = 10
+        self.min_accuracy = 0.95
+
+    def make_xay(self, n_true_confounders, n_samples, seed=None):
+        xa, y = make_classification(n_samples=n_samples,
+                                    n_features=self.max_x_cols + 1,
+                                    n_informative=min(n_true_confounders, self.max_x_cols),
+                                    n_redundant=0, n_repeated=0, class_sep=10.0,
+                                    n_clusters_per_class=1,
+                                    shuffle=False, random_state=seed)
+        xa = StandardScaler().fit_transform(xa)
+        a, x = xa[:, -1], xa[:, :-1]
+        xdf = pd.DataFrame(x, columns=["x_" + str(i) for i in range(x.shape[1])])
+        adf = pd.Series(a)
+        ydf = pd.Series(y)
+        return xdf, adf, ydf
+
+    @staticmethod
+    def fit_transform(X, a, y, n_true_confounders, step=1):
+        estimator = LogisticRegression(penalty='l1', solver='saga', max_iter=5000)
+        rfe = RecursiveConfounderElimination(estimator=estimator,
+                                             n_features_to_select=n_true_confounders,
+                                             step=step)
+        rfe.fit(X, a, y)
+        score = estimator.score(a.to_frame().join(X.iloc[:, rfe.support_]), y)
+        result = rfe.transform(X)
+        return result, score
+
+    def run_config(self, n_true_confounders, n_samples=100, step=1):
+        X, a, y = self.make_xay(n_true_confounders, n_samples)
+        result, score = self.fit_transform(X, a, y, n_true_confounders, step)
+        return result, score
+
+    def test_basic(self):
+        # Basic test with increasing number of confounders.
+        # We check that the required number of confounders are returned.
+        # We also check for accuracy of classifier with retained confounders
+        # as a proxy for how well we recover the confounders.
+        for i in range(self.max_x_cols):
+            n_true_confounders = i + 1
+            result, score = self.run_config(n_true_confounders=n_true_confounders)
+            self.assertEqual(len(result.columns), n_true_confounders)
+            self.assertGreaterEqual(score, self.min_accuracy)
+
+    def test_more_features_than_confounders(self):
+        # Test for n_features_to_select > X.columns: in this case
+        # we should return the entire X as answer.
+        # We also check for accuracy of classifier with retained confounders
+        # as a proxy for how well we recover the confounders.
+        for i in range(10):
+            n_true_confounders = self.max_x_cols + i + 1
+            result, score = self.run_config(n_true_confounders=n_true_confounders)
+            self.assertEqual(len(result.columns), self.max_x_cols)
+            self.assertGreaterEqual(score, self.min_accuracy)
+
+    def test_step(self):
+        # Test for different step sizes (i.e., confounders to eliminate in each step).
+        # We also check for accuracy of classifier with retained confounders
+        # as a proxy for how well we recover the confounders.
+        n_true_confounders = 3
+        for i in range(self.max_x_cols + 5):    # test from step = 1 to > max columns
+            step = i + 1
+            result, score = self.run_config(n_true_confounders=n_true_confounders, step=step)
+            self.assertEqual(len(result.columns), n_true_confounders)
+            self.assertGreaterEqual(score, self.min_accuracy)
+
+    def test_covariates_subset(self):
+        X, a, y = self.make_xay(2, n_samples=100, seed=6)
+        true_subset_confounders = ['x_0']  # Matches random seed: 6
+        covariates_subset = ['x_0', 'x_2', f'x_{X.shape[1] - 1}', f'x_{X.shape[1] - 3}']
+
+        rfe = RecursiveConfounderElimination(
+            estimator=LogisticRegression(),
+            covariates=covariates_subset,
+        )
+
+        rfe = self.ensure_covariate_subset(rfe, X, a, y, true_subset_confounders)
+
+        np.testing.assert_array_equal(covariates_subset, rfe.covariates)
+        self.assertEqual(len(true_subset_confounders), rfe.n_features_)
+
+    def test_covariate_subset_binary(self):
+        X, a, y = self.make_xay(2, n_samples=100, seed=6)
+        true_subset_confounders = ['x_0']  # Matches random seed: 6
+        covariates_subset = ['x_0', 'x_2', f'x_{X.shape[1] - 1}', f'x_{X.shape[1] - 3}']
+        # Convert to binary:
+        true_subset_confounders = X.columns.isin(true_subset_confounders)
+        covariates_subset = X.columns.isin(covariates_subset)
+
+        rfe = RecursiveConfounderElimination(
+            estimator=LogisticRegression(),
+            covariates=covariates_subset,
+        )
+
+        rfe = self.ensure_covariate_subset_binary(rfe, X, a, y, true_subset_confounders)
+
+        np.testing.assert_array_equal(covariates_subset, rfe.covariates)
+        self.assertEqual(true_subset_confounders.sum(), rfe.n_features_)

--- a/causallib/tests/test_doublyrobust.py
+++ b/causallib/tests/test_doublyrobust.py
@@ -153,7 +153,7 @@ class TestDoublyRobustBase(unittest.TestCase):
                     self.estimator.estimate_individual_outcome(data["X"], data["a"])
                     self.assertTrue(True)  # Dummy assert for not thrown exception
 
-    def ensure_many_models(self):
+    def ensure_many_models(self, truncate_eps=None):
         from sklearn.ensemble import GradientBoostingRegressor, RandomForestRegressor
         from sklearn.neural_network import MLPRegressor
         from sklearn.linear_model import ElasticNet, RANSACRegressor, HuberRegressor, PassiveAggressiveRegressor
@@ -172,7 +172,7 @@ class TestDoublyRobustBase(unittest.TestCase):
                                    RandomForestClassifier(n_estimators=100),
                                    MLPClassifier(hidden_layer_sizes=(5,)),
                                    KNeighborsClassifier(n_neighbors=20)]:
-            weight_model = IPW(propensity_learner)
+            weight_model = IPW(propensity_learner, truncate_eps=truncate_eps)
             propensity_learner_name = str(propensity_learner).split("(", maxsplit=1)[0]
             for outcome_learner in [GradientBoostingRegressor(n_estimators=10), RandomForestRegressor(n_estimators=10),
                                     MLPRegressor(hidden_layer_sizes=(5,)),
@@ -339,4 +339,4 @@ class TestDoublyRobustIPFeature(TestDoublyRobustBase):
         self.ensure_pipeline_learner()
 
     def test_many_models(self):
-        self.ensure_many_models()
+        self.ensure_many_models(truncate_eps=0.001)

--- a/docs/source/causallib.contrib.shared_sparsity_selection.rst
+++ b/docs/source/causallib.contrib.shared_sparsity_selection.rst
@@ -1,0 +1,17 @@
+causallib.contrib.shared\_sparsity\_selection package
+=====================================================
+
+Submodules
+----------
+
+.. toctree::
+
+   causallib.contrib.shared_sparsity_selection.shared_sparsity_selection
+
+Module contents
+---------------
+
+.. automodule:: causallib.contrib.shared_sparsity_selection
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/causallib.contrib.shared_sparsity_selection.shared_sparsity_selection.rst
+++ b/docs/source/causallib.contrib.shared_sparsity_selection.shared_sparsity_selection.rst
@@ -1,0 +1,7 @@
+causallib.contrib.shared\_sparsity\_selection.shared\_sparsity\_selection module
+================================================================================
+
+.. automodule:: causallib.contrib.shared_sparsity_selection.shared_sparsity_selection
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/causallib.preprocessing.confounder_selection.rst
+++ b/docs/source/causallib.preprocessing.confounder_selection.rst
@@ -1,0 +1,7 @@
+causallib.preprocessing.confounder\_selection module
+====================================================
+
+.. automodule:: causallib.preprocessing.confounder_selection
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/causallib.tests.test_confounder_selection.rst
+++ b/docs/source/causallib.tests.test_confounder_selection.rst
@@ -1,0 +1,7 @@
+causallib.tests.test\_confounder\_selection module
+==================================================
+
+.. automodule:: causallib.tests.test_confounder_selection
+   :members:
+   :undoc-members:
+   :show-inheritance:


### PR DESCRIPTION
A confounder selection module for reducing high-dimensional covariate-spaces with causal relevance.

Models:
* [Double Lasso](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=2733374) - Fitting sparse _Y~X_ and _A~X_ regressors and selecting the union (or any provided function) of the non-zero coefficients.
* [Recursive elimination](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3166439/) - iteratively remove features, but always condition on the treatment assignment.
* [Shared treatment sparsity](https://proceedings.mlr.press/v130/greenewald21a.html) - for each treatment value fit a regressor with a special dedicated regularization term, and select the non-zero coefficients across all treatment models.

Additionally, selection can be done only on a subset of covariates (specified in the `covariates` parameter). This allows users to force the selection algorithms to keep some prespecified covariates. 

Major contributions by @onkarbhardwaj