### PR TITLE
Augmented Inverse Probability Weighting (AIPW)

### DIFF
--- a/causallib/estimation/__init__.py
+++ b/causallib/estimation/__init__.py
@@ -1,7 +1,4 @@
-from .doubly_robust import (
-    PropensityFeatureStandardization, WeightedStandardization,
-    ResidualCorrectedStandardization,
-)
+from .doubly_robust import AIPW, PropensityFeatureStandardization, WeightedStandardization
 from .ipw import IPW
 from .overlap_weights import OverlapWeights
 from .standardization import Standardization, StratifiedStandardization

--- a/causallib/estimation/__init__.py
+++ b/causallib/estimation/__init__.py
@@ -1,6 +1,6 @@
 from .doubly_robust import (
     PropensityFeatureStandardization, WeightedStandardization,
-    ResidualCorrectedStandardization, AIPW,
+    ResidualCorrectedStandardization,
 )
 from .ipw import IPW
 from .overlap_weights import OverlapWeights

--- a/causallib/estimation/__init__.py
+++ b/causallib/estimation/__init__.py
@@ -1,4 +1,7 @@
-from .doubly_robust import PropensityFeatureStandardization, WeightedStandardization, ResidualCorrectedStandardization
+from .doubly_robust import (
+    PropensityFeatureStandardization, WeightedStandardization,
+    ResidualCorrectedStandardization, AIPW,
+)
 from .ipw import IPW
 from .overlap_weights import OverlapWeights
 from .standardization import Standardization, StratifiedStandardization

--- a/causallib/estimation/doubly_robust.py
+++ b/causallib/estimation/doubly_robust.py
@@ -100,7 +100,7 @@ class BaseDoublyRobust(IndividualOutcomeEstimator):
         return repr_string
 
 
-class ResidualCorrectedStandardization(BaseDoublyRobust):
+class AIPW(BaseDoublyRobust):
     def __init__(self, outcome_model, weight_model,
                  outcome_covariates=None, weight_covariates=None,
                  overlap_weighting=False):

--- a/causallib/tests/test_plots.py
+++ b/causallib/tests/test_plots.py
@@ -16,7 +16,7 @@
 
 from sklearn.linear_model import LogisticRegression, LinearRegression
 from causallib.evaluation import PropensityEvaluator, OutcomeEvaluator
-from causallib.estimation import ResidualCorrectedStandardization, IPW, StratifiedStandardization
+from causallib.estimation import AIPW, IPW, StratifiedStandardization
 from causallib.datasets import load_nhefs
 import unittest
 import pandas as pd
@@ -31,7 +31,7 @@ class TestPlots(unittest.TestCase):
         self.data = load_nhefs()
         ipw = IPW(LogisticRegression(solver="liblinear"), clip_min=0.05, clip_max=0.95)
         std = StratifiedStandardization(LinearRegression())
-        self.dr = ResidualCorrectedStandardization(std, ipw)
+        self.dr = AIPW(std, ipw)
         self.dr.fit(self.data.X, self.data.a, self.data.y)
         self.prp_evaluator = PropensityEvaluator(self.dr.weight_model)
         self.out_evaluator = OutcomeEvaluator(self.dr.outcome_model)

--- a/examples/doubly_robust.ipynb
+++ b/examples/doubly_robust.ipynb
@@ -23,7 +23,7 @@
     "from sklearn.linear_model import LogisticRegression, LinearRegression\n",
     "from causallib.datasets import load_nhefs\n",
     "from causallib.estimation import IPW, Standardization, StratifiedStandardization\n",
-    "from causallib.estimation import ResidualCorrectedStandardization, PropensityFeatureStandardization, WeightedStandardization\n",
+    "from causallib.estimation import AIPW, PropensityFeatureStandardization, WeightedStandardization\n",
     "from causallib.evaluation import PropensityEvaluator, OutcomeEvaluator"
    ]
   },
@@ -257,7 +257,7 @@
     {
      "data": {
       "text/plain": [
-       "ResidualCorrectedStandardization(outcome_covariates=None, outcome_model=StratifiedStandardization(learner=LinearRegression(copy_X=True, fit_intercept=True, n_jobs=None,\n",
+       "AIPW(outcome_covariates=None, outcome_model=StratifiedStandardization(learner=LinearRegression(copy_X=True, fit_intercept=True, n_jobs=None,\n",
        "         normalize=False)), predict_proba=False, weight_covariates=None,\n",
        "                    weight_model=IPW(clip_min=0.05, clip_max=0.95, use_stabilized=False,\n",
        "    learner=LogisticRegression(C=1.0, class_weight=None, dual=False, fit_intercept=True,\n",
@@ -274,7 +274,7 @@
    "source": [
     "ipw = IPW(LogisticRegression(solver=\"liblinear\"), clip_min=0.05, clip_max=0.95)\n",
     "std = StratifiedStandardization(LinearRegression())\n",
-    "dr = ResidualCorrectedStandardization(std, ipw)\n",
+    "dr = AIPW(std, ipw)\n",
     "dr.fit(data.X, data.a, data.y)"
    ]
   },
@@ -749,7 +749,7 @@
    "source": [
     "ipw = IPW(LogisticRegression(solver=\"liblinear\"), clip_min=0.05, clip_max=0.95)\n",
     "std = Standardization(LinearRegression(), encode_treatment=True)\n",
-    "dr = ResidualCorrectedStandardization(std, ipw)"
+    "dr = AIPW(std, ipw)"
    ]
   },
   {

--- a/examples/fast_food_employment_card_krueger.ipynb
+++ b/examples/fast_food_employment_card_krueger.ipynb
@@ -450,7 +450,7 @@
     "from causallib.estimation import (\n",
     "    PropensityFeatureStandardization,\n",
     "    WeightedStandardization,\n",
-    "    ResidualCorrectedStandardization,\n",
+    "    AIPW,\n",
     "    IPW,\n",
     "    MarginalOutcomeEstimator,\n",
     "    Standardization,\n",
@@ -478,7 +478,7 @@
     "    StratifiedStandardization(learner=LinearRegression()),\n",
     "    PropensityFeatureStandardization(makestd(), makeipw()),\n",
     "    WeightedStandardization(makestd(), makeipw()),\n",
-    "    ResidualCorrectedStandardization(makestd(), makeipw()),\n",
+    "    AIPW(makestd(), makeipw()),\n",
     "]\n",
     "\n",
     "\n",
@@ -581,7 +581,7 @@
        "      <td>1.042494</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>ResidualCorrectedStandardization</th>\n",
+       "      <th>AIPW</th>\n",
        "      <td>16.653759</td>\n",
        "      <td>17.673968</td>\n",
        "      <td>1.020210</td>\n",
@@ -600,7 +600,7 @@
        "StratifiedStandardization               16.664511  17.672040  1.007530\n",
        "PropensityFeatureStandardization        16.686028  17.638321  0.952293\n",
        "WeightedStandardization                 16.625123  17.667617  1.042494\n",
-       "ResidualCorrectedStandardization        16.653759  17.673968  1.020210"
+       "AIPW                                    16.653759  17.673968  1.020210"
       ]
      },
      "execution_count": 8,
@@ -1003,7 +1003,7 @@
        "      <td>1.763000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>ResidualCorrectedStandardization</th>\n",
+       "      <th>AIPW</th>\n",
        "      <td>17.429092</td>\n",
        "      <td>19.193340</td>\n",
        "      <td>1.764248</td>\n",
@@ -1022,7 +1022,7 @@
        "StratifiedStandardization               17.431684  19.198245  1.766561\n",
        "PropensityFeatureStandardization        17.500168  18.502095  1.001927\n",
        "WeightedStandardization                 17.429642  19.192642  1.763000\n",
-       "ResidualCorrectedStandardization        17.429092  19.193340  1.764248"
+       "AIPW                                    17.429092  19.193340  1.764248"
       ]
      },
      "execution_count": 14,


### PR DESCRIPTION
Completing PR https://github.com/IBM/causallib/pull/28.

[Glynn and Quinn (2010)](https://www.law.berkeley.edu/files/AIPW(1).pdf) present a version of AIPW that is different from the one described in [Kang and Schafer (2007, section 3.1)](https://projecteuclid.org/journals/statistical-science/volume-22/issue-4/Demystifying-Double-Robustness--A-Comparison-of-Alternative-Strategies-for/10.1214/07-STS227.full). 
The two methods are comparable, but slightly differ from one another: 
* K&S present a version that adds IP-weighed residuals of the outcome and the factual-outcome prediction (attributed to Cassel, Särndal and Wretman). 
* G&Q (citing [Robins, Rotnitzky, and Zhao (1994)](https://cdn1.sph.harvard.edu/wp-content/uploads/sites/343/2013/03/estim-regress-94.pdf)) additionally weigh the factual-outcome prediction with overlap-weights (i.e. the propensity of the opposite treatment group), and then calculate the residuals and IP-weigh it.  
  This might be beneficial as it will rely less on outcome-prediction of extreme-propensity data points - those lacking covariate overlap and more prone to model extrapolation. However, since it also rely on opposite-group, it is limited to a binary-treatment setting. 

Since both versions are frequently referred to as "AIPW", and since code overlap a lot, it is better to consolidate them to a single AIPW class.


Additionally, following up on the changes in https://github.com/IBM/causallib/pull/28,
It appears [Bang and Robins 2005](https://doi.org/10.1111/j.1541-0420.2005.00377.x) has a [2008 errata](https://doi.org/10.1111/j.1541-0420.2008.01025.x) describing the IP-feature as needing a negation to the control group (matching with Hernán and Robins book Fine Point 13.2, and aligning with the ATE-targeted version of TMLE). 
Additionally, a masked-IPW matrix (described as `e(∆, V; β , φ1, φ2)` in B&R) is also added.
These two were previously commented out, as they seem to have bigger variance (less-efficient) than the other methods on some simple simulated datasets, but they are theoretically justifiable, so they are added anyway.