### PR TITLE
limit n_neighbors to n_samples before matching

### DIFF
--- a/causallib/tests/test_matching.py
+++ b/causallib/tests/test_matching.py
@@ -641,3 +641,17 @@ class TestMatching(unittest.TestCase):
             prepickle_estimate, postpickle_estimate)
         np.testing.assert_array_equal(
             prepickle_covariates, postpickle_covariates)
+
+    def test_matching_one_way_works_even_when_other_is_undefined(self):
+        X, a, y = self.data_serial_unbalanced_x
+        for n_neighbors in [5, 20, 50]:
+            self.check_matching_too_few_neighbors_adapts_matches(n_neighbors, X, a, y)
+
+    def check_matching_too_few_neighbors_adapts_matches(self, n_neighbors, X, a, y):
+        matching = Matching(n_neighbors=n_neighbors, matching_mode="treatment_to_control")
+        matching.fit(X,a,y)
+        match_df = matching.match(X, a)
+        n_matches_actual = match_df.distances.apply(len).groupby(level=0).max()
+        self.assertEqual(n_matches_actual[0], min(n_neighbors, self.n))
+        self.assertEqual(n_matches_actual[1], min(n_neighbors, self.k))
+        


### PR DESCRIPTION
Closes https://github.com/IBM/causallib/issues/37 .

Because of how matching is executed based on sklearn, both directions are matched even if only one is requested. The filtering by direction happens when the results are reported, not at match time. Therefore you can have a situation as reported in the linked issue in which one direction has enough neighbors to match while the other direction does not and neither directions work. 

The proposed solution is to enable one direction of matching even when the other has too few samples. In reality it does execute the matching in both directions, but the problematic direction is limited to `n_samples == n_neighbors` and a warning is printed to screen. 

Failing unit test which is reproduces the problem and is fixed by this code is added in this PR as well.