### PR TITLE
Causal model selection

### DIFF
--- a/causallib/estimation/base_estimator.py
+++ b/causallib/estimation/base_estimator.py
@@ -32,10 +32,12 @@ import warnings
 import pandas as pd
 from numpy import isscalar
 
+from sklearn.base import BaseEstimator
+
 from ..utils.general_tools import create_repr_string
 
 
-class EffectEstimator:
+class EffectEstimator(BaseEstimator):
     """
     Class-based interface for estimating either individual-level or sample-level effect.
     """

--- a/causallib/estimation/standardization.py
+++ b/causallib/estimation/standardization.py
@@ -111,6 +111,7 @@ class StratifiedStandardization(IndividualOutcomeEstimator):
             self.learner = learner
         elif treatment_values is not None:  # overwrite native `learner` with dictionary based one
             self.learner = self._clone_learner(treatment_values)
+        self.treatment_values = treatment_values
 
     def _clone_learner(self, treatment_values):
         """
@@ -161,8 +162,9 @@ class StratifiedStandardization(IndividualOutcomeEstimator):
         return res
 
     def fit(self, X, a, y, sample_weight=None):
+        self.treatment_values_ = g_tools.get_iterable_treatment_values(None, a)
         if not isinstance(self.learner, dict):  # sk-learner was not cloned yet to have one copy for each stratum
-            self.learner = self._clone_learner(a.unique())
+            self.learner = self._clone_learner(self.treatment_values_)
 
         for cur_X, cur_y, cur_sw, treatment_value in self._prepare_data(X, a, y, sample_weight):
             fit_params = _add_sample_weight_fit_params(self.learner[treatment_value], cur_sw)

--- a/causallib/evaluation/metrics.py
+++ b/causallib/evaluation/metrics.py
@@ -1,14 +1,10 @@
-"""General metric functions for causal evaluation."""
+"""Apply machine learning metrics to causal models for evaluation."""
 import warnings
 
 import numpy as np
 import pandas as pd
 from sklearn import metrics
 
-from ..utils.stat_utils import (
-    calc_weighted_ks2samp,
-    calc_weighted_standardized_mean_differences,
-)
 
 NUMERICAL_CLASSIFICATION_METRICS = {
     "accuracy": metrics.accuracy_score,
@@ -36,22 +32,12 @@ REGRESSION_METRICS = {
     "expvar": metrics.explained_variance_score,
     "mae": metrics.mean_absolute_error,
     "mse": metrics.mean_squared_error,
-#    "msle": metrics.mean_squared_log_error, #uncomment if predictions are all positive
+    # "msle": metrics.mean_squared_log_error, #uncomment if predictions are all positive
     # Allow mdae receive sample_weight argument but ignore it. This unifies the interface:
     "mdae": lambda y_true, y_pred, **kwargs: metrics.median_absolute_error(
         y_true, y_pred
     ),
     "r2": metrics.r2_score,
-}
-
-DISTRIBUTION_DISTANCE_METRICS = {
-    "smd": lambda x, y, wx, wy: calc_weighted_standardized_mean_differences(
-        x, y, wx, wy
-    ),
-    "abs_smd": lambda x, y, wx, wy: abs(
-        calc_weighted_standardized_mean_differences(x, y, wx, wy)
-    ),
-    "ks": lambda x, y, wx, wy: calc_weighted_ks2samp(x, y, wx, wy),
 }
 
 
@@ -140,84 +126,3 @@ def _metric_needs_proba(metric_name):
     }
 
     return use_proba
-
-
-# ################# #
-# Covariate Balance #
-# ################# #
-
-
-def calculate_covariate_balance(X, a, w, metric="abs_smd"):
-    """Calculate covariate balance table ("table 1")
-
-    Args:
-        X (pd.DataFrame): Covariates.
-        a (pd.Series): Group assignment of each sample.
-        w (pd.Series): sample weights for balancing between groups in `a`.
-        metric (str | callable): Either a key from DISTRIBUTION_DISTANCE_METRICS or a metric with
-            the signature weighted_distance(x, y, wx, wy) calculating distance between the weighted
-            sample x and weighted sample y (weights by wx and wy respectively).
-
-    Returns:
-        pd.DataFrame: index are covariate names (columns) from X, and columns are
-            "weighted" / "unweighted" results of applying `metric` on each covariate
-            to compare the two groups.
-    """
-    treatment_values = np.sort(np.unique(a))
-    results = {}
-    for treatment_value in treatment_values:
-        distribution_distance_of_cur_treatment = pd.DataFrame(
-            index=X.columns, columns=["weighted", "unweighted"], dtype=float
-        )
-        for col_name, col_data in X.items():
-            weighted_distance = calculate_distribution_distance_for_single_feature(
-                col_data, w, a, treatment_value, metric
-            )
-            unweighted_distance = calculate_distribution_distance_for_single_feature(
-                col_data, pd.Series(1, index=w.index), a, treatment_value, metric
-            )
-            distribution_distance_of_cur_treatment.loc[
-                col_name, ["weighted", "unweighted"]
-            ] = [weighted_distance, unweighted_distance]
-        results[treatment_value] = distribution_distance_of_cur_treatment
-    results = pd.concat(
-        results, axis="columns", names=[a.name or "a", metric]
-    )  # type: pd.DataFrame
-    results.index.name = "covariate"
-    if len(treatment_values) == 2:
-        # If there are only two treatments, the results for both are identical.
-        # Therefore, we can get rid from one of them.
-        # We keep the results for the higher valued treatment group (assumed treated, typically 1):
-        results = results.xs(treatment_values.max(), axis="columns", level=0)
-    # TODO: is there a neat expansion for multi-treatment case?
-    #  maybe not current_treatment vs. the rest.
-    return results
-
-
-def calculate_distribution_distance_for_single_feature(
-    x, w, a, group_level, metric="abs_smd"
-):
-    """
-
-    Args:
-        x (pd.Series): A single feature to check balancing.
-        a (pd.Series): Group assignment of each sample.
-        w (pd.Series): sample weights for balancing between groups in `a`.
-        group_level: Value from `a` in order to divide the sample into one vs. rest.
-        metric (str | callable): Either a key from DISTRIBUTION_DISTANCE_METRICS or a metric with
-            the signature weighted_distance(x, y, wx, wy) calculating distance between the weighted
-            sample x and weighted sample y (weights by wx and wy respectively).
-
-    Returns:
-        float: weighted distance between the samples assigned to `group_level`
-            and the rest of the samples.
-    """
-    if not callable(metric):
-        metric = DISTRIBUTION_DISTANCE_METRICS[metric]
-    cur_treated_mask = a == group_level
-    x_treated = x.loc[cur_treated_mask]
-    w_treated = w.loc[cur_treated_mask]
-    x_untreated = x.loc[~cur_treated_mask]
-    w_untreated = w.loc[~cur_treated_mask]
-    distribution_distance = metric(x_treated, x_untreated, w_treated, w_untreated)
-    return distribution_distance

--- a/causallib/evaluation/plots/data_extractors.py
+++ b/causallib/evaluation/plots/data_extractors.py
@@ -9,8 +9,7 @@ import abc
 from sklearn import metrics
 
 from . import curve_data_makers, plots
-from ...utils.stat_utils import is_vector_binary
-from ..metrics import calculate_covariate_balance
+from ...metrics.weight_metrics import calculate_covariate_balance
 
 
 class BaseEvaluationPlotDataExtractor(abc.ABC):

--- a/causallib/evaluation/predictions.py
+++ b/causallib/evaluation/predictions.py
@@ -9,10 +9,9 @@ import warnings
 
 import pandas as pd
 from ..utils.stat_utils import robust_lookup
-from .metrics import (
-    calculate_covariate_balance,
-    evaluate_metrics,
-)
+from .metrics import evaluate_metrics
+from ..metrics.weight_metrics import calculate_covariate_balance
+
 
 WeightEvaluatorScores = namedtuple(
     "WeightEvaluatorScores", ["prediction_scores", "covariate_balance"]

--- a/causallib/metrics/__init__.py
+++ b/causallib/metrics/__init__.py
@@ -1,0 +1,7 @@
+from .propensity_metrics import weighted_roc_auc_error, expected_roc_auc_error
+from .propensity_metrics import weighted_roc_curve_error, expected_roc_curve_error
+from .propensity_metrics import ici_error
+from .weight_metrics import covariate_balancing_error
+from .outcome_metrics import balanced_residuals_error
+
+from .scorers import get_scorer, get_scorer_names

--- a/causallib/metrics/outcome_metrics.py
+++ b/causallib/metrics/outcome_metrics.py
@@ -1,0 +1,84 @@
+"""
+Metrics to assess performance of direct-outcome (counterfactual prediction) models.
+Function named as ``*_error`` return a scalar value to minimize:
+the lower, the better.
+
+Metrics' interface doesn't strictly follow skleran's metrics interface.
+The outcome prediction is expected to be full potential outcome prediction
+(one column for each treatment value), and also expects the true treatment assignment.
+"""
+
+import numpy as np
+import pandas as pd
+
+from causallib.evaluation.weight_evaluator import calculate_covariate_balance
+from causallib.utils.stat_utils import calc_weighted_standardized_mean_differences, calc_weighted_ks2samp
+from causallib.utils.stat_utils import robust_lookup
+
+
+def abs_standardized_mean_difference(a, b, **kwargs):
+    asmd = calc_weighted_standardized_mean_differences(
+        a, b,
+        wx=np.ones_like(a),
+        wy=np.ones_like(b),
+    )
+    asmd = np.abs(asmd)
+    return asmd
+
+
+def _get_observed_outcome_prediction(potential_outcomes, a):
+    # TODO: duplicated throughout causallib. move to utils or standardization module
+    is_predict_proba_classification_result = isinstance(potential_outcomes.columns, pd.MultiIndex)
+    if is_predict_proba_classification_result:
+        # Classification `outcome_model` with `predict_proba=True` returns
+        # a MultiIndex treatment-values (`a`) over outcome-values (`y`)
+        # Extract the prediction for the maximal outcome class
+        # (probably class `1` in binary classification):
+        outcome_values = potential_outcomes.columns.get_level_values(level=-1)
+        potential_outcomes = potential_outcomes.xs(
+            outcome_values.max(), axis="columns", level=-1, drop_level=True,
+        )
+    potential_outcomes = robust_lookup(potential_outcomes, a)
+    return potential_outcomes
+
+
+def balanced_residuals_error(
+    y_true, y_pred, a_true,
+    distance_metric=abs_standardized_mean_difference,
+    distance_metric_kwargs=None,
+):
+    """Computes how different is the residuals distribution of the control group
+    from that of the treatment group.
+    Residuals are based on the observed (factual) outcome prediction.
+
+    Can plug in any uni-variate two-sample test function.
+
+    Args:
+        y_true (pd.Series): The true observed outcomes.
+        y_pred (pd.DataFrame): Potential outcome prediction, the output of `estimate_individual_outcome()`.
+                               A matrix of (n_samples, n_treatments), with column names as the treatment values.
+        a_true (pd.Series): A vector of observed treatment assignment.
+        distance_metric (callable): A two sample test function.
+            First argument is the residual values of the treatment group, second is for the control group.
+            Defaults to absolute standardized mean difference.
+        distance_metric_kwargs (dict): Additional keyword arguments needed for the `distance_metric` function.
+
+    Returns:
+        score (float):
+    """
+    if distance_metric_kwargs is None:
+        distance_metric_kwargs = {}
+
+    y_pred = _get_observed_outcome_prediction(y_pred, a_true)
+
+    residuals = y_true - y_pred
+    treatment_mask = a_true == a_true.max()
+    control_mask = a_true == a_true.min()
+
+    score = distance_metric(
+        residuals[treatment_mask],
+        residuals[control_mask],
+        **distance_metric_kwargs,
+    )
+    return score
+

--- a/causallib/metrics/outcome_metrics.py
+++ b/causallib/metrics/outcome_metrics.py
@@ -11,8 +11,7 @@ The outcome prediction is expected to be full potential outcome prediction
 import numpy as np
 import pandas as pd
 
-from causallib.evaluation.weight_evaluator import calculate_covariate_balance
-from causallib.utils.stat_utils import calc_weighted_standardized_mean_differences, calc_weighted_ks2samp
+from causallib.utils.stat_utils import calc_weighted_standardized_mean_differences
 from causallib.utils.stat_utils import robust_lookup
 
 

--- a/causallib/metrics/propensity_metrics.py
+++ b/causallib/metrics/propensity_metrics.py
@@ -1,0 +1,163 @@
+"""
+Metrics to assess performance of propensity score models.
+Function named as ``*_error`` return a scalar value to minimize:
+the lower, the better.
+
+Metrics' interface doesn't strictly follow skleran's metrics interface.
+Names are kept as `y_true` and `y_pred` even though these regard the
+treatment assignment `a` (`a_true`, `a_pred` [propensity]).
+"""
+
+import numpy as np
+from numpy import interp
+from sklearn.metrics import roc_auc_score, roc_curve
+import statsmodels.api as sm
+
+
+def weighted_roc_auc_error(y_true, y_pred, sample_weight):
+    """
+    Compute the squared error between the balanced (e.g. IP-weighted) ROC AUC
+    to the diagonal, i.e. AUC=0.5.
+
+    Shimoni, Y., et al. (2019)
+    An evaluation toolkit to guide model selection and cohort definition in causal inference.
+
+    Args:
+        y_true (pd.Series): True binary label assignment of size (num_subjects,)
+        y_pred (pd.Series): Predicted probability of each sample being
+                            the positive label of size (num_subjects,).
+        sample_weight (pd.Series | None): Weights of size (num_subjects,)
+
+    Returns:
+        score (float):
+    """
+    weighted_auc = roc_auc_score(y_true, y_pred, sample_weight=sample_weight)
+    chance_auc = 0.5
+    score = (weighted_auc - chance_auc) ** 2
+    return score
+
+
+def expected_roc_auc_error(y_true, y_pred, **kwargs):
+    """
+    Compute the squared error between the expected ROC-AUC given the provided
+    scores and the actual ROC-AUC they produce.
+
+    Shimoni, Y., et al. (2019)
+    An evaluation toolkit to guide model selection and cohort definition in causal inference.
+
+    Args:
+        y_true (pd.Series): True binary label assignment of size (num_subjects,)
+        y_pred (pd.Series): Predicted probability of each sample being
+                            the positive label of size (num_subjects,).
+
+    Returns:
+        score (float):
+    """
+    # Calculate expected roc auc:
+    p = np.hstack((y_pred, y_pred))
+    w = np.hstack((y_pred, 1 - y_pred))
+    target = np.hstack((np.ones_like(y_pred), np.zeros_like(y_pred)))
+    expected_auc = roc_auc_score(target, p, sample_weight=w)
+
+    auc = roc_auc_score(y_true, y_pred)
+    score = (expected_auc - auc) ** 2
+    return score
+
+
+def weighted_roc_curve_error(y_true, y_pred, sample_weight, agg=np.max):
+    """Compute the absolute differences between the balanced (e.g. IP-weighted) ROC curve
+    and the diagonal x=y curve.
+    Since difference in curves results in a multiple values (each point along the curve),
+    an aggregation function is also required.
+
+    Shimoni, Y., et al. (2019)
+    An evaluation toolkit to guide model selection and cohort definition in causal inference.
+
+    Args:
+        y_true (pd.Series): True binary label assignment of size (num_subjects,)
+        y_pred (pd.Series): Predicted probability of each sample being
+                            the positive label of size (num_subjects,).
+        sample_weight (pd.Series | None): Weights of size (num_subjects,)
+        agg (callable): A function to aggregate a vector of absolute differences
+                        between the curves' points. Default is max.
+
+    Returns:
+        score (float):
+    """
+    weighted_roc_fpr, weighted_roc_tpr, _ = roc_curve(
+        y_true, y_pred, sample_weight=sample_weight
+    )
+    diagonal = weighted_roc_fpr
+    diff = np.abs(weighted_roc_tpr - diagonal)
+    score = agg(diff)
+    return score
+
+
+def expected_roc_curve_error(y_true, y_pred, agg=np.max, **kwargs):
+    """Compute the absolute differences between the expected ROC curve and the regular
+    ROC curve of the model.
+    Since difference in curves results in a multiple values (each point along the curve),
+    an aggregation function is also required.
+
+    Shimoni, Y., et al. (2019)
+    An evaluation toolkit to guide model selection and cohort definition in causal inference.
+
+    Args:
+        y_true (pd.Series): True binary label assignment of size (num_subjects,)
+        y_pred (pd.Series): Predicted probability of each sample being
+                            the positive label of size (num_subjects,).
+        agg (callable): A function to aggregate a vector of absolute differences
+                        between the curves' points. Default is max.
+
+    Returns:
+        score (float):
+    """
+    # Calculate expected roc curve:
+    p = np.hstack((y_pred, y_pred))
+    w = np.hstack((y_pred, 1 - y_pred))
+    target = np.hstack((np.ones_like(y_pred), np.zeros_like(y_pred)))
+    expected_fpr, expected_tpr, _ = roc_curve(target, p, sample_weight=w)
+
+    fpr, tpr, _ = roc_curve(y_true, y_pred)
+
+    # Align the FPR/TPR so the difference vector is meaningful:
+    fpr_domain = np.linspace(0, 1, 100)
+    tpr_interp = interp(fpr_domain, fpr, tpr)
+    tpr_interp[0] = 0.0
+    expected_tpr_interp = interp(fpr_domain, expected_fpr, expected_tpr)
+    expected_tpr_interp[0] = 0.0
+
+    diff = np.abs(tpr_interp - expected_tpr_interp)
+    score = agg(diff)
+    return score
+
+
+def ici_error(y_true, y_pred, agg=np.mean, lowess_kwargs=None, **kwargs):
+    """Integrated calibration index metric.
+    Fits a lowess model between binary treatment assignment and the predicted probabilities.
+    This generates a smooth calibration curve,
+    which we can subtract from the diagonal, and examine magnitude.
+    To make a single-number score the absolute difference is then aggregated using mean, median, max,
+    or whatever collapses a vector into a single number.
+
+    See: Austin and Steyerberg (2019): The Integrated Calibration Index (ICI)
+    and related metrics for quantifying the calibration of logistic regression models.
+    """
+    if lowess_kwargs is None:
+        lowess_kwargs = {}
+
+    smooth_curve = sm.nonparametric.lowess(
+        y_true, y_pred,
+        **lowess_kwargs
+        # TODO: maybe force prediction domain xval=linspace(0, 1, num=0) or linspace(y_true.min(), y_true.max(), num=0)
+    )
+    # See `out` in doc: https://www.statsmodels.org/dev/generated/statsmodels.nonparametric.smoothers_lowess.lowess.html
+    if len(smooth_curve.shape) == 2:  # `return_sorted==True`
+        y_pred = smooth_curve[:, 0]
+        smooth_curve = smooth_curve[:, 1]
+
+    diff = np.abs(smooth_curve - y_pred)
+    score = agg(diff)
+    return score
+
+

--- a/causallib/metrics/scorers.py
+++ b/causallib/metrics/scorers.py
@@ -1,0 +1,165 @@
+"""
+This submodule implements a scorer interface for the
+various causal metrics implemented.
+These scorers can then be incorporated into model selection objects
+to select the models (or hyperparameters) that optimizes these scores.
+For example, as a `scoring` parameter to a `causallib.model_selection.GridSearchCV
+object.
+
+The signature of the call is ``(estimator, X, a, y)`` where ``estimator``
+is the causal model to be evaluated, ``X`` are the covariates,
+`a` is the treatment assignment, and ``y`` is the ground truth target
+"""
+# from sklearn.metrics._scorer import _BaseScorer
+import abc
+
+from . import (
+    propensity_metrics,
+    weight_metrics,
+    outcome_metrics,
+)
+
+
+class _BaseCausalScorer:
+    def __init__(self, score_func, sign, **kwargs):
+        self._score_func = score_func
+        self._sign = sign
+        self._kwargs = kwargs
+
+    def __call__(self, estimator, X, a_true, y_true, sample_weight=None, **kwargs):
+        return self._sign * self._score(
+            estimator,
+            X,
+            a_true,
+            y_true,
+            sample_weight=sample_weight,
+            **{**self._kwargs, **kwargs},
+        )
+
+    @abc.abstractmethod
+    def _score(self, estimator, X, a, y, sample_weight=None, **kwargs):
+        raise NotImplementedError
+
+
+class PropensityScorerBase(_BaseCausalScorer):
+    def _score(self, estimator, X, a, y, sample_weight=None, **kwargs):
+        propensities = estimator.compute_propensity(X, a)
+        weights = estimator.compute_weights(X, a)
+        score = self._score_func(
+            a, propensities, sample_weight=weights,
+            **kwargs
+        )
+        return score
+
+
+weighted_roc_auc_error_scorer = PropensityScorerBase(
+    propensity_metrics.weighted_roc_auc_error, -1,
+)
+weighted_roc_curve_error_scorer = PropensityScorerBase(
+    propensity_metrics.weighted_roc_curve_error, -1,
+)
+expected_roc_auc_error_scorer = PropensityScorerBase(
+    propensity_metrics.expected_roc_auc_error, -1,
+)
+expected_roc_curve_error_scorer = PropensityScorerBase(
+    propensity_metrics.expected_roc_curve_error, -1
+)
+ici_error_scorer = PropensityScorerBase(
+    propensity_metrics.ici_error, -1,
+)
+
+_PROPENSITY_SCORERS = dict(
+    weighted_roc_auc_error=weighted_roc_auc_error_scorer,
+    weighted_roc_curve_error=weighted_roc_curve_error_scorer,
+    expected_roc_auc_error=expected_roc_auc_error_scorer,
+    expected_roc_curve_error=expected_roc_curve_error_scorer,
+    ici_error=ici_error_scorer,
+
+)
+
+
+class WeightScorerBase(_BaseCausalScorer):
+    def _score(self, estimator, X, a, y, sample_weight=None, **kwargs):
+        weights = estimator.compute_weights(X, a)
+        score = self._score_func(
+            X, a, sample_weight=weights,
+            **kwargs
+        )
+        return score
+
+
+covariate_balancing_error_scorer = WeightScorerBase(
+    weight_metrics.covariate_balancing_error, -1,
+)
+
+_WEIGHT_SCORERS = dict(
+    covariate_balancing_error=covariate_balancing_error_scorer,
+)
+
+
+class OutcomeScorerBase(_BaseCausalScorer):
+    def _score(self, estimator, X, a, y, sample_weight=None, **kwargs):
+        potential_outcomes_pred = estimator.estimate_individual_outcome(X, a)
+        score = self._score_func(
+            y, potential_outcomes_pred, a,
+            **kwargs
+            # Is this a good generic API call to the outcome metrics?
+        )
+        return score
+
+
+balanced_residuals_error_scorer = OutcomeScorerBase(
+    outcome_metrics.balanced_residuals_error, -1,
+)
+
+_OUTCOME_SCORERS = dict(
+    balanced_residuals_error=balanced_residuals_error_scorer,
+)
+
+_SCORERS = {
+    **_PROPENSITY_SCORERS,
+    **_WEIGHT_SCORERS,
+    **_OUTCOME_SCORERS
+}
+
+
+def get_scorer(scoring):
+    """Gets a scorer callable from string.
+    see `causallib.metrics.get_scorer_names` to retrieve available score names.
+    """
+    if callable(scoring):
+        return scoring
+    try:
+        return _SCORERS.get(scoring)
+    except KeyError:
+        raise ValueError(
+            f"Scoring name {scoring} is not a valid scoring name."
+            f"use the `causallib.metrics.get_scorer_names` to get all valid names."
+        )
+
+
+def get_scorer_names(score_type="all"):
+    """Get the name of all available scorers.
+    These names can be passed to `causallib.metrics.get_scorer` to retrieve a scorer object.
+
+    Args:
+        score_type (str): any of {"all", "propensity", "weight", "outcome"}.
+            Returns only scorers relevant to the `score_type` type of model.
+
+    Returns:
+
+    """
+    scores_types_map = {
+        "all": _SCORERS,
+        "propensity": _PROPENSITY_SCORERS,
+        "weight": _WEIGHT_SCORERS,
+        "outcome": _OUTCOME_SCORERS,
+    }
+    try:
+        return sorted(scores_types_map[score_type])
+    except KeyError:
+        raise ValueError(
+            f"`score_type` {score_type} is not valid."
+            f"Please use one of {scores_types_map.keys()}."
+        )
+

--- a/causallib/metrics/weight_metrics.py
+++ b/causallib/metrics/weight_metrics.py
@@ -5,7 +5,101 @@ the lower, the better.
 
 Metrics' interface doesn't strictly follow skleran's metrics interface.
 """
-from causallib.evaluation.weight_evaluator import calculate_covariate_balance
+
+import pandas as pd
+import numpy as np
+
+from ..utils.stat_utils import (
+    calc_weighted_ks2samp,
+    calc_weighted_standardized_mean_differences,
+)
+
+DISTRIBUTION_DISTANCE_METRICS = {
+    "smd": lambda x, y, wx, wy: calc_weighted_standardized_mean_differences(
+        x, y, wx, wy
+    ),
+    "abs_smd": lambda x, y, wx, wy: abs(
+        calc_weighted_standardized_mean_differences(x, y, wx, wy)
+    ),
+    "ks": lambda x, y, wx, wy: calc_weighted_ks2samp(x, y, wx, wy),
+}
+
+
+def calculate_covariate_balance(X, a, w, metric="abs_smd"):
+    """Calculate covariate balance table ("table 1")
+
+    Args:
+        X (pd.DataFrame): Covariates.
+        a (pd.Series): Group assignment of each sample.
+        w (pd.Series): sample weights for balancing between groups in `a`.
+        metric (str | callable): Either a key from DISTRIBUTION_DISTANCE_METRICS or a metric with
+            the signature weighted_distance(x, y, wx, wy) calculating distance between the weighted
+            sample x and weighted sample y (weights by wx and wy respectively).
+
+    Returns:
+        pd.DataFrame: index are covariate names (columns) from X, and columns are
+            "weighted" / "unweighted" results of applying `metric` on each covariate
+            to compare the two groups.
+    """
+    treatment_values = np.sort(np.unique(a))
+    results = {}
+    for treatment_value in treatment_values:
+        distribution_distance_of_cur_treatment = pd.DataFrame(
+            index=X.columns, columns=["weighted", "unweighted"], dtype=float
+        )
+        for col_name, col_data in X.items():
+            weighted_distance = calculate_distribution_distance_for_single_feature(
+                col_data, w, a, treatment_value, metric
+            )
+            unweighted_distance = calculate_distribution_distance_for_single_feature(
+                col_data, pd.Series(1, index=w.index), a, treatment_value, metric
+            )
+            distribution_distance_of_cur_treatment.loc[
+                col_name, ["weighted", "unweighted"]
+            ] = [weighted_distance, unweighted_distance]
+        results[treatment_value] = distribution_distance_of_cur_treatment
+    results = pd.concat(
+        results, axis="columns", names=[a.name or "a", metric]
+    )  # type: pd.DataFrame
+    results.index.name = "covariate"
+    if len(treatment_values) == 2:
+        # If there are only two treatments, the results for both are identical.
+        # Therefore, we can get rid of one of them.
+        # We keep the results for the higher valued treatment group (assumed treated, typically 1):
+        results = results.xs(treatment_values.max(), axis="columns", level=0)
+    # TODO: is there a neat expansion for multi-treatment case?
+    #  maybe not current_treatment vs. the rest.
+    return results
+
+
+def calculate_distribution_distance_for_single_feature(
+    x, w, a, group_level, metric="abs_smd"
+):
+    """
+
+    Args:
+        x (pd.Series): A single feature to check balancing.
+        a (pd.Series): Group assignment of each sample.
+        w (pd.Series): sample weights for balancing between groups in `a`.
+        group_level: Value from `a` in order to divide the sample into one vs. rest.
+        metric (str | callable): Either a key from DISTRIBUTION_DISTANCE_METRICS or a metric with
+            the signature weighted_distance(x, y, wx, wy) calculating distance between the weighted
+            sample x and weighted sample y (weights by wx and wy respectively).
+
+    Returns:
+        float: weighted distance between the samples assigned to `group_level`
+            and the rest of the samples.
+    """
+    if not callable(metric):
+        metric = DISTRIBUTION_DISTANCE_METRICS[metric]
+    cur_treated_mask = a == group_level
+    x_treated = x.loc[cur_treated_mask]
+    w_treated = w.loc[cur_treated_mask]
+    x_untreated = x.loc[~cur_treated_mask]
+    w_untreated = w.loc[~cur_treated_mask]
+    distribution_distance = metric(x_treated, x_untreated, w_treated, w_untreated)
+    return distribution_distance
+
 
 
 def covariate_balancing_error(X, a, sample_weight, agg=max):

--- a/causallib/metrics/weight_metrics.py
+++ b/causallib/metrics/weight_metrics.py
@@ -1,0 +1,28 @@
+"""
+Metrics to assess performance of weight models.
+Function named as ``*_error`` return a scalar value to minimize:
+the lower, the better.
+
+Metrics' interface doesn't strictly follow skleran's metrics interface.
+"""
+from causallib.evaluation.weight_evaluator import calculate_covariate_balance
+
+
+def covariate_balancing_error(X, a, sample_weight, agg=max):
+    """Computes the weighted (i.e. balanced) absolute standardized mean difference
+    of every covariate in X.
+
+    Args:
+        X (pd.DataFrame): Covariate matrix.
+        a (pd.Series): Treatment assignment vector.
+        sample_weight (pd.Series): Weights balancing between the treatment groups.
+        agg (callable): A function to aggregate a vector of absolute differences
+                        between the curves' points. Default is max.
+
+    Returns:
+        score (float):
+    """
+    asmds = calculate_covariate_balance(X, a, sample_weight, metric="abs_smd")
+    weighted_asmds = asmds["weighted"]
+    score = agg(weighted_asmds)
+    return score

--- a/causallib/model_selection/__init__.py
+++ b/causallib/model_selection/__init__.py
@@ -1,0 +1,9 @@
+from sklearn.model_selection import GridSearchCV as skGridSearchCV
+from sklearn.model_selection import RandomizedSearchCV as skRandomizedSearchCV
+
+from .search import causalize_searcher
+from .split import TreatmentOutcomeStratifiedKFold
+from .split import TreatmentStratifiedKFold
+
+GridSearchCV = causalize_searcher(skGridSearchCV)
+RandomizedSearchCV = causalize_searcher(skRandomizedSearchCV)

--- a/causallib/model_selection/search.py
+++ b/causallib/model_selection/search.py
@@ -1,0 +1,164 @@
+"""
+Interfacing between causallib and sklearn to take advantage of sklearn's
+hyperparameter search machinery (e.g., GridSearchCV).
+Wraps causallib's models and scorers to look like sklearn's,
+and wraps sklearn's hyperparameter search models to look like causallib models.
+"""
+from typing import Type
+
+from sklearn.model_selection._search import BaseSearchCV
+import pandas as pd
+
+from ..metrics.scorers import get_scorer
+
+
+def _adapt_causal_scorer_to_sklearn(scorer):
+    """Wraps a Causal Scorer, whose interface is `estimator, X, a, y, **kwargs`,
+    with a sklearn-compatible interface of `estimator, Xa, y, **kwargs`.
+
+    Args:
+        scorer (callable): a causallib scorer.
+
+    Returns:
+        score (callable): a scikit-learn score interface for `scorer`.
+    """
+    def score(estimator, joinedXa, y_true, sample_weight=None, **kwargs):
+        a = joinedXa.iloc[:, -1]
+        X = joinedXa.iloc[:, :-1]
+        score_value = scorer(estimator, X, a, y_true, sample_weight=sample_weight, **kwargs)
+        return score_value
+    return score
+
+
+def _adapt_causal_scorers_to_sklearn(scorers):
+    """Wraps each causallib scorer in a possible dict/list of them.
+    Only supports causallib's scorers.
+    Mostly compatible with `scoring` parameter in:
+    https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.GridSearchCV.html
+
+    Args:
+        scorers (str, callable, list, tuple, dict):
+            A strategy to evaluate the performance a causallib model. can be either single or multiple scores.
+
+            If `scorers` represents a single score, one can use:
+            * A string (see causallib.metrics.get_scorer_names for all available names).
+            * A callable following the API in causallib.metrics.scorers: `estimator, X, a, y, **kwargs`.
+
+            If `scorers` represents multiple scores, one can use:
+            * A list or tuple of scorer names.
+            * A dict mapping between metric names and callable scorers (following the API in causallib.metrics.scorers).
+
+    Returns:
+        scores (callable, list, dict): a callable or a list/dict of callables (depending on the input),
+            of causal scorers compatible with sklearn's scorers' API.
+    """
+    # TODO: adapt only if isinstance of BaseCausalScorer and leave sklearn's scorers untouched?
+    if isinstance(scorers, dict):
+        scorers = {name: _adapt_causal_scorer_to_sklearn(scorer)
+                   for name, scorer in scorers.items()}
+    elif isinstance(scorers, (list, tuple)):
+        scorers = {name: _adapt_causal_scorer_to_sklearn(get_scorer(name))
+                   for name in scorers}
+    elif isinstance(scorers, str):
+        scorers = _adapt_causal_scorer_to_sklearn(get_scorer(scorers))
+    elif callable(scorers):
+        scorers = _adapt_causal_scorer_to_sklearn(scorers)
+    else:
+        raise ValueError(
+            f"`scoring` is invalid (got {scorers})."
+            f"Please provide either: "
+            f"a callable compatible with causallib.metrics.scorers API,"
+            f"a scorer name from causallib.metrics.get_scorer_names,"
+            f"a list or tuple of scorer names,"
+            f"or a dictionary mapping between metric names and valid scorers"
+        )
+    return scorers
+
+
+def _adapt_causal_estimator_to_sklearn(estimator):
+    """Wraps a causallib model (type) with interface `fit(X, a, y)`
+    with a sklearn's `fit(X', y)` interface.
+    Other than that, it has the same (inference) capabilities as the causallib estimator.
+    """
+    class SklearnCompatibleEstimator(estimator.__class__):
+        def fit(self, joinedXa, y, *args, **kwargs):
+            a = joinedXa.iloc[:, -1]
+            X = joinedXa.iloc[:, :-1]
+            return super().fit(X, a, y, *args, **kwargs)
+
+        @property
+        def estimator(self):
+            params = self.get_params()
+            return estimator.set_params(**params)
+
+    SklearnCompatibleEstimator.__name__ = f"SklearnCompatible{estimator.__class__.__name__}"
+    SklearnCompatibleEstimator.__qualname__ = f"SklearnCompatible{estimator.__class__.__qualname__}"
+    params = estimator.get_params()
+    return SklearnCompatibleEstimator(learner=params["learner"]).set_params(**params)
+
+
+def causalize_searcher(searcher_type: Type[BaseSearchCV]):
+    """wraps a hyperparameter search algorithm (like sklearn's GridSearchCV)
+    with a causallib model interface.
+
+    Args:
+        searcher_type: A class of hyperparameter search algorithm
+            (e.g., sklearn's GridSearchCV)
+
+    Returns:
+        searcher(searcher_type): a class definition of the provided searcher
+            with a causallib `fit(X, a, y)` interface and the underlying estimator capabilities.
+
+    Examples:
+        >>> from sklearn.model_selection import GridSearchCV
+        >>> from sklearn.linear_model import LogisticRegression
+        >>> from causallib.estimation import IPW
+        >>> from causallib.metrics import get_scorer
+        >>> from causallib.datasets import load_nhefs
+        >>> data = load_nhefs()
+        >>> CausalGridSearchCV = causalize_searcher(GridSearchCV)
+        >>> model = IPW(LogisticRegression())
+        >>> scorer = get_scorer("weighted_roc_auc_error")
+        >>> param_grid = dict(clip_min=[0.2, 0.3])
+        >>> grid_model = CausalGridSearchCV(model, param_grid=param_grid, scoring=scorer)  # GridSearchCV parameters
+        >>> grid_model.fit(data.X, data.a, data.y)  # causallib interface
+        >>> grid_model.estimate_population_outcome(data.X, data.a, data.y)
+        >>> grid_model.compute_propensity(data.X, data.a)  # IPW capabilities
+
+    """
+    class CausalSearcher(searcher_type):
+        def __init__(self, estimator, *args, **kwargs):
+            estimator = _adapt_causal_estimator_to_sklearn(estimator)
+            kwargs["scoring"] = _adapt_causal_scorers_to_sklearn(kwargs["scoring"])
+            super().__init__(estimator, *args, **kwargs)
+
+        def _set_methods_from_estimator(self):
+            """Exposes all the methods from the internal `best_estimator_`,
+            so that the `CausalSearcher` behaves like it's internal causallib model.
+            """
+            # Avoid re-setting and overwriting existing methods:
+            unique_estimator_attributes = set(dir(self.best_estimator_)) - set(dir(self))
+            for attr_name in dir(self.best_estimator_):
+                attr_value = getattr(self.best_estimator_, attr_name, None)
+                if (
+                    attr_name in unique_estimator_attributes  # An estimator attribute that is not unique to searcher
+                    and not attr_name.startswith("__")  # not internal method
+                    and callable(attr_value)  # the current attribute is a method
+                    and attr_name != "fit"  # don't overwrite the GridSearch-like fit below.
+                ):
+                    setattr(self, attr_name, attr_value)
+
+        def fit(self, X, a, y, *, groups=None, **fit_params):
+            joinedXa = pd.concat([X, a], axis=1)
+            super().fit(joinedXa, y, groups=groups, **fit_params)
+            # if hasattr(self, "best_estimator_"):
+            #     self.best_estimator_ = self.estimator.estimator
+            # # Should `best_estimator_` be original causallib model or adapted?
+            self._set_methods_from_estimator()
+            return self
+
+    CausalSearcher.__name__ = f"Causal{searcher_type.__name__}"
+    CausalSearcher.__qualname__ = f"Causal{searcher_type.__qualname__}"
+    return CausalSearcher
+
+

--- a/causallib/model_selection/split.py
+++ b/causallib/model_selection/split.py
@@ -1,0 +1,74 @@
+from itertools import product
+
+import numpy as np
+import pandas as pd
+
+from sklearn.model_selection import StratifiedKFold
+from sklearn.utils.multiclass import type_of_target
+
+
+class TreatmentOutcomeStratifiedKFold(StratifiedKFold):
+    """Creates stratified folds based on both the treatment assignment 
+    and the outcome. 
+    That is, every fold preserves both the treatment prevalence and
+    outcome prevalence within each treatment. 
+    
+    For non-class outcomes, stratification is done only based on treatment. 
+    
+    """
+    __doc__ += StratifiedKFold.__doc__
+
+    @staticmethod
+    def _combine_treatment_outcome_labels(a, y):
+        """combines every `a` x `y` values as a unique label"""
+        # Assuming n_a < 10, n_y < 10: labels = a*10+y. Implements a generic version.
+        a_unique = np.unique(a)
+        y_unique = np.unique(y)
+        combinations = product(a_unique, y_unique)
+        combinations_mapping = {c: i for i, c in enumerate(combinations)}
+        combined_labels = [combinations_mapping[(ai, yi)] for ai, yi in zip(a, y)]
+        combined_labels = pd.Series(combined_labels, index=a.index)
+        return combined_labels
+
+    def _get_labels_for_split(self, a, y):
+        target_type = type_of_target(y)
+        if target_type not in ("binary", "multiclass"):
+            # `y` is incompatible with stratification
+            raise ValueError(
+                f"Outcome type should either be 'binary' or 'multiclass'."
+                f"Received {target_type} instead."
+            )
+        labels = self._combine_treatment_outcome_labels(a, y)
+        return labels
+
+    def split(self, joinedXa, y, groups=None):
+        X = joinedXa.iloc[:, :-1]
+        a = joinedXa.iloc[:, -1]
+        splits = self._split(X, a, y, groups=groups)
+        # labels = self._get_labels_for_split(a, y)
+        # splits = super().split(X, labels, groups=groups)
+        return splits
+
+    def _split(self, X, a, y, groups=None):
+        """A causallib-like `X, a, y` interface for split"""
+        labels = self._get_labels_for_split(a, y)
+        splits = super().split(X, labels, groups=groups)
+        return splits
+
+
+class TreatmentStratifiedKFold(StratifiedKFold):
+    """Creates stratified folds based on the treatment assignment.
+    That is, every fold preserves the treatment prevalence.
+    """
+    __doc__ += StratifiedKFold.__doc__
+
+    def split(self, joinedXa, y=None, groups=None):
+        X = joinedXa.iloc[:, :-1]
+        a = joinedXa.iloc[:, -1]
+        splits = self._split(X, a, y, groups=groups)
+        return splits
+
+    def _split(self, X, a, y=None, groups=None):
+        """A causallib-like `X, a, y` interface for split"""
+        splits = super().split(X, a, groups=groups)
+        return splits

--- a/causallib/tests/test_metrics.py
+++ b/causallib/tests/test_metrics.py
@@ -1,0 +1,316 @@
+import unittest
+import numpy as np
+import pandas as pd
+from sklearn.datasets import make_classification
+from sklearn.linear_model import LogisticRegression, LinearRegression
+
+from causallib.metrics import weighted_roc_auc_error, expected_roc_auc_error
+from causallib.metrics import weighted_roc_curve_error, expected_roc_curve_error
+from causallib.metrics import ici_error
+from causallib.metrics import covariate_balancing_error
+from causallib.metrics import balanced_residuals_error
+
+
+class TestPropensityMetrics(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Data:
+        X, a = make_classification(
+            n_features=1, n_informative=1, n_redundant=0, n_repeated=0,
+            n_classes=2, n_clusters_per_class=1, flip_y=0.0, class_sep=0.5,
+            random_state=0,
+        )
+        cls.data_r_100 = {"X": pd.DataFrame(X), "a": pd.Series(a)}
+
+        # RCT Data:
+        np.random.seed(0)
+        X = np.random.normal(0, 1, 10000)
+        a = np.random.binomial(1, 0.5, 10000)
+        cls.data_rct = {"X": pd.DataFrame(X), "a": pd.Series(a)}
+
+        # Hard-coded Data:
+        y = pd.Series([0, 0, 0, 0, 0, 1, 1, 1, 1, 1])
+        y_pred = pd.Series([0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 1, 1])
+        y_chance = pd.Series(10 * [0.5])
+        w_uniform = pd.Series(10 * [0.1])
+        w = pd.Series([1 / 6, 1 / 6, 1 / 6, 1 / 6, 1 / 6, 1 / 6, 0, 0, 0, 0])
+
+        cls.hard_coded_data = {
+            "y": y,
+            "y_chance": y_chance,
+            "y_pred": y_pred,
+            "w_uniform": w_uniform,
+            "w": w
+        }
+
+        # # Avoids regularization of the model:
+        cls.estimator = LogisticRegression(penalty='none', solver='sag', max_iter=2000)
+
+    def test_weighted_roc_auc(self):
+        with self.subTest("Chance predictions"):
+            expected = 0
+            observed = weighted_roc_auc_error(
+                y_true=self.hard_coded_data['y'],
+                y_pred=self.hard_coded_data['y_chance'],
+                sample_weight=self.hard_coded_data['w_uniform']
+            )
+            self.assertEqual(observed, expected)
+
+        with self.subTest("Random label fitting"):
+            self.estimator.fit(self.data_rct['X'], self.data_rct['a'])
+            a_pred = self.estimator.predict_proba(self.data_rct['X'])
+            ip_weights = 1 / a_pred[range(a_pred.shape[0]), self.data_rct['a']]
+            expected = 0
+            observed = weighted_roc_auc_error(
+                y_true=self.data_rct['a'],
+                y_pred=a_pred[:, 1],
+                sample_weight=ip_weights
+            )
+            self.assertAlmostEqual(observed, expected, places=6)
+
+        with self.subTest("Good separation"):
+            self.estimator.fit(self.data_r_100['X'], self.data_r_100['a'])
+            a_pred = self.estimator.predict_proba(self.data_r_100['X'])
+            ip_weights = 1 / a_pred[range(a_pred.shape[0]), self.data_r_100['a']]
+            expected = 0.25  # The result for this data
+            observed = weighted_roc_auc_error(
+                y_true=self.data_r_100['a'],
+                y_pred=a_pred[:, 1],
+                sample_weight=ip_weights
+            )
+            self.assertAlmostEqual(observed, expected, places=4)
+
+        with self.subTest("Perfect prediction but uniform weights"):
+            # When the weights are uniform, i.e. weight_sample=1/n, W-AUC is
+            # similar to AUC. Here, the prediction is perfect and the
+            # W-AUC=AUC=1. The squared error is (W-AUC-0.5)**2=0.25
+            expected = 0.25
+            observed = weighted_roc_auc_error(
+                y_true=self.hard_coded_data['y'],
+                y_pred=self.hard_coded_data['y'],
+                sample_weight=self.hard_coded_data['w_uniform']
+            )
+            self.assertEqual(observed, expected)
+
+        with self.subTest("Uniform weighted AUC"):
+            # W-AUC and AUC are similar, but smaller than 1.
+            weighted_auc_uniform = weighted_roc_auc_error(
+                y_true=self.hard_coded_data['y'],
+                y_pred=self.hard_coded_data['y_pred'],
+                sample_weight=self.hard_coded_data['w_uniform']
+            )
+            self.assertLess(weighted_auc_uniform, 0.25)
+
+        with self.subTest("Non-uniform weights should be closer to the diagonal"):
+            # The weights are not uniform, and the W-AUC is closer to the diagonal
+            weighted_auc = weighted_roc_auc_error(
+                y_true=self.hard_coded_data['y'],
+                y_pred=self.hard_coded_data['y_pred'],
+                sample_weight=self.hard_coded_data['w']
+            )
+            self.assertLess(weighted_auc, weighted_auc_uniform)
+
+    def test_expected_roc_auc_error(self):
+        with self.subTest("Identical prediction, perfect alignment"):
+            expected_roc_auc = expected_roc_auc_error(
+                y_true=self.hard_coded_data['y'],
+                y_pred=self.hard_coded_data['y']
+            )
+            self.assertEqual(expected_roc_auc, 0.0)
+
+        with self.subTest("Good calibration"):
+            expected_roc_auc = expected_roc_auc_error(
+                y_true=self.hard_coded_data['y'],
+                y_pred=self.hard_coded_data['y_pred']
+            )
+            self.assertAlmostEqual(0, expected_roc_auc, places=2)
+
+    def test_weighted_roc_curve(self):
+        with self.subTest("Chance predictions"):
+            expected = 0
+            observed = weighted_roc_curve_error(
+                y_true=self.hard_coded_data['y'],
+                y_pred=self.hard_coded_data['y_chance'],
+                sample_weight=self.hard_coded_data['w_uniform']
+            )
+            self.assertEqual(observed, expected)
+
+        with self.subTest("Random label fitting"):
+            self.estimator.fit(self.data_rct['X'], self.data_rct['a'])
+            a_pred = self.estimator.predict_proba(self.data_rct['X'])
+            ip_weights = 1 / a_pred[range(a_pred.shape[0]), self.data_rct['a']]
+            expected = 0  # 0.0130
+            observed = weighted_roc_curve_error(
+                y_true=self.data_rct['a'],
+                y_pred=a_pred[:, 1],
+                sample_weight=ip_weights
+            )
+            self.assertAlmostEqual(observed, expected, places=1)
+
+        with self.subTest("Perfect separation"):
+            self.estimator.fit(self.data_r_100['X'], self.data_r_100['a'])
+            a_pred = self.estimator.predict_proba(self.data_r_100['X'])
+            ip_weights = 1 / a_pred[range(a_pred.shape[0]), self.data_r_100['a']]
+            expected = 1.0
+            observed = weighted_roc_curve_error(
+                y_true=self.data_r_100['a'],
+                y_pred=a_pred[:, 1],
+                sample_weight=ip_weights
+            )
+            self.assertAlmostEqual(observed, expected, places=4)
+
+        with self.subTest("Perfect prediction but uniform weights"):
+            # perfect prediction so the difference from diagonal is 1 (top-left minus bottom-left corner)
+            expected = 1.0
+            observed = weighted_roc_curve_error(
+                y_true=self.hard_coded_data['y'],
+                y_pred=self.hard_coded_data['y'],
+                sample_weight=self.hard_coded_data['w_uniform']
+            )
+            self.assertEqual(observed, expected)
+
+        with self.subTest("Uniform weighted ROC curve"):
+            expected = 0.4  # The result from this `y_pred` assignment
+            weighted_auc_uniform = weighted_roc_curve_error(
+                y_true=self.hard_coded_data['y'],
+                y_pred=self.hard_coded_data['y_pred'],
+                sample_weight=self.hard_coded_data['w_uniform']
+            )
+            self.assertEqual(weighted_auc_uniform, expected)
+
+        with self.subTest("Non-uniform weights should be closer to the diagonal"):
+            # The weights are not uniform, and the W-AUC is closer to the diagonal
+            weighted_auc = weighted_roc_curve_error(
+                y_true=self.hard_coded_data['y'],
+                y_pred=self.hard_coded_data['y_pred'],
+                sample_weight=self.hard_coded_data['w']
+            )
+            self.assertLess(weighted_auc, weighted_auc_uniform)
+
+    def test_expected_roc_curve_error(self):
+        with self.subTest("Identical prediction, perfect alignment"):
+            expected_roc_auc = expected_roc_curve_error(
+                y_true=self.hard_coded_data['y'],
+                y_pred=self.hard_coded_data['y']
+            )
+            self.assertEqual(expected_roc_auc, 0.0)
+
+        with self.subTest("Good calibration"):
+            expected_roc_auc = expected_roc_curve_error(
+                y_true=self.hard_coded_data['y'],
+                y_pred=self.hard_coded_data['y_pred']
+            )
+            expected = 0.0539
+            self.assertAlmostEqual(expected_roc_auc, expected, places=3)
+
+    def test_different_agg_function_in_curve(self):
+        with self.subTest("Weighted ROC curve"):
+            # perfect prediction so the difference from diagonal is 1 (top-left minus bottom-left corner)
+            expected = 1/3  # 3-point curve: bottom-left (0 difference), top-left (1), top-right (0)
+            observed = weighted_roc_curve_error(
+                y_true=self.hard_coded_data['y'],
+                y_pred=self.hard_coded_data['y'],
+                sample_weight=self.hard_coded_data['w_uniform'],
+                agg=np.mean
+            )
+            self.assertEqual(observed, expected)
+
+        with self.subTest("Expected ROC curve"):
+            expected = 0.0  # Equal curve so diff=0 all the way
+            observed = expected_roc_curve_error(
+                y_true=self.hard_coded_data['y'],
+                y_pred=self.hard_coded_data['y'],
+                agg=np.mean,
+            )
+            self.assertEqual(observed, expected)
+
+    def test_ici(self):
+        data = {  # Reduce size since lowess can be slow
+            'X': self.data_rct['X'].loc[:200],
+            'a': self.data_rct['a'].loc[:200],
+        }
+        self.estimator.fit(data['X'], data['a'])
+        a_pred = self.estimator.predict_proba(data['X'])[:, 1]
+
+        with self.subTest("Default parameters"):
+            ici_score = ici_error(data['a'], a_pred)
+            expected = 0.0239
+            self.assertAlmostEqual(ici_score, expected, places=3)
+
+        with self.subTest("`return_sorted==False`"):
+            ici_score = ici_error(
+                data['a'], a_pred,
+                lowess_kwargs={"return_sorted": False}
+            )
+            expected = 0.0239
+            self.assertAlmostEqual(ici_score, expected, places=3)
+
+
+class TestWeightMetrics(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        a = pd.Series([0]*6 + [1]*6)
+        X = pd.DataFrame(
+            {
+                "x1": [1, 0] * 6,  # Perfectly balanced
+                "x2": [0]*5 + [1, 0] + [1]*5,  # Almost perfectly imbalance (pure imbalance crashes when standardizing)
+            }
+        )
+        w = pd.Series(data=1/6, index=a.index)
+        cls.data = {"X": X, "a": a, "w": w}
+
+        # # Avoids regularization of the model:
+        cls.estimator = LogisticRegression(penalty='none', solver='sag', max_iter=2000)
+
+    def test_covariate_balancing(self):
+        score = covariate_balancing_error(self.data["X"], self.data["a"], self.data["w"])
+        expected = (5/6 - 1/6) / np.sqrt(0.13888 + 0.13888)
+        self.assertAlmostEqual(score, expected, places=4)
+
+        with self.subTest("Test `mean` agg function"):
+            score = covariate_balancing_error(
+                self.data["X"], self.data["a"], self.data["w"],
+                agg=np.mean,
+            )
+            expected /= 2  # Two features, the second has 0 ASMD
+            self.assertAlmostEqual(score, expected, places=4)
+
+
+class TestOutcomeMetrics(unittest.TestCase):
+    def test_balanced_residuals(self):
+        a = pd.Series([0]*5 + [1]*6)  # Unequal group sizes
+        y = pd.Series([8, 9, 10, 11, 12,
+                       18, 19, 20, 20, 21, 22])
+        y_pred = pd.DataFrame({  # Will only use the observed predictions
+            0: [10]*5 + [np.nan]*6,
+            1: [np.nan]*5 + [20]*6,
+        })
+
+        score = balanced_residuals_error(y, y_pred, a)
+        expected = 0
+        self.assertAlmostEqual(score, expected)
+
+        with self.subTest("Custom distance metric"):
+            from scipy.stats import ks_2samp
+            score = balanced_residuals_error(
+                y, y_pred, a,
+                distance_metric=lambda y0, y1: ks_2samp(y1, y0)[0]  # Return KS statistic
+            )
+            expected = 0.06666666666  # Result per KS
+            self.assertAlmostEqual(score, expected)
+
+        with self.subTest("Biased residuals"):
+            bias = 5
+            y_pred_bias = y_pred.copy()
+            y_pred_bias.loc[a == 1] += bias
+            # Simple un-standardized mean-difference should reproduce the bias
+            score = balanced_residuals_error(
+                y, y_pred_bias, a,
+                distance_metric=lambda y1, y0: abs(y1.mean() - y0.mean())
+            )
+            expected = bias
+            self.assertEqual(score, expected)
+
+
+# if __name__ == '__main__':
+#     unittest.main()

--- a/causallib/tests/test_scorers.py
+++ b/causallib/tests/test_scorers.py
@@ -1,0 +1,206 @@
+import abc
+import unittest
+
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import LogisticRegression, LinearRegression
+
+from causallib.estimation import IPW, StratifiedStandardization
+
+from causallib.metrics import get_scorer, get_scorer_names
+
+
+class BaseTestScorer(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        np.random.seed(0)
+        # Data:
+        # X, a = make_classification(
+        #     n_features=1, n_informative=1, n_redundant=0, n_repeated=0,
+        #     n_classes=2, n_clusters_per_class=1, flip_y=0.0, class_sep=0.5,
+        #     random_state=0,
+        # )
+        n = 1000
+        d = 2
+        X = np.random.normal(scale=3, size=(n, d))
+        beta_Xa = np.random.normal(size=d)
+        a_logit = X @ beta_Xa  # + np.random.normal(size=n)
+        a_propensity = 1 / (1 + np.exp(-a_logit))
+        a = np.random.binomial(1, a_propensity)
+        beta_Xy = np.random.normal(size=d)
+        beta_a = 5
+        y = X @ beta_Xy + a * beta_a + np.random.normal(size=n)
+        cls.data = {
+            "X": pd.DataFrame(X),
+            "a": pd.Series(a),
+            "y": pd.Series(y),
+        }
+
+        # RCT Data:
+        np.random.seed(0)
+        X = np.random.normal(0, 1, 1000)
+        a = np.random.binomial(1, 0.5, 1000)
+        y = X * 1 + a * 5 + np.random.normal(size=X.shape[0])
+        cls.data_rct = {
+            "X": pd.DataFrame(X),
+            "a": pd.Series(a),
+            "y": pd.Series(y),
+        }
+
+        # # Avoids regularization of the model:
+        cls.estimator = IPW(LogisticRegression(penalty='none', solver='sag', max_iter=2000))
+
+    def ensure_single_scoring_does_not_fail(self, scoring_name, data):
+        scorer = get_scorer(scoring_name)
+        score = scorer(
+            self.estimator,
+            data['X'], data['a'], data['y'],
+        )
+        self.assertIsInstance(score, float)
+        self.assertLess(score, 0)
+
+    def ensure_multiple_scoring_do_not_fail(self, score_type):
+        self.estimator.fit(self.data['X'], self.data['a'], self.data['y'])
+        scoring_names = get_scorer_names(score_type)
+        for scoring_name in scoring_names:
+            with self.subTest(f"Testing {scoring_name} does not fail."):
+                self.ensure_single_scoring_does_not_fail(scoring_name, self.data)
+
+    @abc.abstractmethod
+    @unittest.skip
+    def test_multiple_scoring_do_not_fail(self):
+        pass
+
+
+class TestPropensityScorer(BaseTestScorer):
+
+    def test_multiple_scoring_do_not_fail(self):
+        self.ensure_multiple_scoring_do_not_fail("propensity")
+
+    def test_scoring_with_kwargs(self):
+        self.estimator.fit(self.data['X'], self.data['a'], self.data['y'])
+
+        with self.subTest("single known kwarg:"):
+            scorer = get_scorer("weighted_roc_curve_error")
+            score_default = scorer(
+                self.estimator,
+                self.data['X'], self.data['a'], self.data['y'],
+            )
+            score_agg_min = scorer(
+                self.estimator,
+                self.data['X'], self.data['a'], self.data['y'],
+                agg=np.min,
+            )
+            self.assertLess(abs(score_agg_min), abs(score_default))
+            # Default is max. scores are negative metrics values due to lower-is-better
+
+        with self.subTest("multiple known kwargs"):
+            scorer = get_scorer("ici_error")
+            score_default = scorer(
+                self.estimator,
+                self.data['X'], self.data['a'], self.data['y'],
+            )
+            score_kwargs = scorer(
+                self.estimator,
+                self.data['X'], self.data['a'], self.data['y'],
+                agg=np.max,
+                lowess_kwargs=dict(frac=0.2),
+            )
+            self.assertLess(abs(score_default), abs(score_kwargs))
+            # Default is mean. scores are negative metrics values due to lower-is-better
+
+        # @unittest.expectedFailure
+        # with self.subTest("passing unknown kwargs"):
+        #     propensity_scoring_names = get_scorer_names("propensity")
+        #     for scoring_name in propensity_scoring_names:
+        #         with self.subTest(f"Testing unknown kwarg in {scoring_name}."):
+        #             scorer = get_scorer(scoring_name)
+        #             score = scorer(
+        #                 self.estimator,
+        #                 self.data['X'], self.data['a'], self.data['y'],
+        #                 nonexistingkwarg="shouldn't_exist!",
+        #             )
+        #             self.assertLess(0, score)
+
+
+class TestWeightScorer(BaseTestScorer):
+    def test_multiple_scoring_do_not_fail(self):
+        self.ensure_multiple_scoring_do_not_fail("weight")
+
+    def test_scoring_with_kwargs(self):
+        self.estimator.fit(self.data['X'], self.data['a'], self.data['y'])
+        scorer = get_scorer("covariate_balancing_error")
+        score_default = scorer(
+            self.estimator,
+            self.data['X'], self.data['a'], self.data['y'],
+        )
+        score_agg_min = scorer(
+            self.estimator,
+            self.data['X'], self.data['a'], self.data['y'],
+            agg=np.min,
+        )
+        self.assertLess(-score_agg_min, -score_default)  # Default is max. Scores are negative metrics values
+
+
+class TestOutcomeScorer(BaseTestScorer):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.estimator = StratifiedStandardization(LinearRegression())
+
+    def test_multiple_scoring_do_not_fail(self):
+        self.ensure_multiple_scoring_do_not_fail("outcome")
+
+    def test_scoring_with_kwargs(self):
+        self.estimator.fit(self.data['X'], self.data['a'], self.data['y'])
+        scorer = get_scorer("balanced_residuals_error")
+        score_default = scorer(
+            self.estimator,
+            self.data['X'], self.data['a'], self.data['y'],
+        )
+        score_mean_diff = scorer(
+            self.estimator,
+            self.data['X'], self.data['a'], self.data['y'],
+            distance_metric=lambda y0, y1: np.abs(y1.mean() - y0.mean())
+        )
+        self.assertLess(-score_default, -score_mean_diff)  # Default is standardized, scores are negatives
+
+    def test_multiple_outcome_models(self):
+        from causallib.estimation import (
+            Standardization, StratifiedStandardization,
+            PropensityFeatureStandardization,
+            WeightedStandardization,
+            TMLE,
+            RLearner,
+        )
+        models = [
+            Standardization(LinearRegression()),
+            StratifiedStandardization(LinearRegression()),
+            PropensityFeatureStandardization(
+                Standardization(LinearRegression()),
+                IPW(LogisticRegression())
+            ),
+            WeightedStandardization(
+                Standardization(LinearRegression()),
+                IPW(LogisticRegression())
+            ),
+            TMLE(
+                Standardization(LinearRegression()),
+                IPW(LogisticRegression())
+            ),
+            RLearner(
+                LinearRegression(),
+                LinearRegression(),
+                LogisticRegression(),
+            )
+        ]
+        for model in models:
+            with self.subTest(f"Test scoring of model"):
+                model.fit(self.data['X'], self.data['a'], self.data['y'])
+                scorer = get_scorer("balanced_residuals_error")
+                score = scorer(
+                    model,
+                    self.data['X'], self.data['a'], self.data['y'],
+                )
+                self.assertIsInstance(score, float)
+

--- a/causallib/tests/test_search.py
+++ b/causallib/tests/test_search.py
@@ -1,0 +1,296 @@
+import unittest
+import pandas as pd
+import numpy as np
+
+from sklearn.linear_model import LogisticRegression, LinearRegression
+from sklearn.ensemble import GradientBoostingRegressor, GradientBoostingClassifier
+from sklearn.model_selection import GridSearchCV
+
+from causallib.estimation import IPW
+from causallib.estimation import AIPW
+from causallib.estimation import StratifiedStandardization, Standardization
+from causallib.metrics import get_scorer
+
+from causallib.model_selection import causalize_searcher
+
+
+class TestGridSearch(unittest.TestCase):
+    @classmethod
+    def _generate_data(cls, n=100, d=4):
+        np.random.seed(1)
+        priors = np.random.uniform(0.1, 0.9, size=d)
+        X = np.random.binomial(1, priors, size=(n, d))
+
+        beta_a = np.random.normal(size=d)
+        intercept_a = np.random.normal()
+        a_logit = intercept_a + X @ beta_a + np.random.normal(size=n)
+        a_propensity = 1 / (1 + np.exp(-a_logit))
+        a = np.random.binomial(1, a_propensity)
+
+        beta_y = np.random.normal(size=d)
+        intercept_y = np.random.normal()
+        treatment_effect = -3
+        y = intercept_y + X @ beta_y + treatment_effect * a + np.random.normal(size=n)
+
+        X = pd.DataFrame(X, columns=[f"x{i}" for i in range(X.shape[1])])
+        a = pd.Series(a, name="treatment")
+        y = pd.Series(y, name="outcome")
+        data = dict(X=X, a=a, y=y)
+        return data
+
+    @classmethod
+    def setUpClass(cls):
+        cls.data = cls._generate_data()
+
+    def _fit_search_model(self, estimator, scoring, param_grid, data=None, cv=2, **search_kwargs):
+        if data is None:
+            data = self.data
+        CausalGridSearchCV = causalize_searcher(GridSearchCV)
+        grid_model = CausalGridSearchCV(
+            estimator,
+            param_grid=param_grid,
+            scoring=scoring,
+            cv=cv,
+            **search_kwargs,
+        )
+        grid_model.fit(data['X'], data['a'], data['y'])
+        return grid_model
+
+    def test_single_propensity_scorer(self):
+        data = self.data
+        model = IPW(LogisticRegression(penalty="none", solver="saga", max_iter=10000))
+        scorer = get_scorer("weighted_roc_auc_error")
+        grid_model = self._fit_search_model(model, scorer, dict(clip_min=[0.2, 0.3]))
+
+        self.assertIsInstance(grid_model.best_estimator_, model.__class__)
+        grid_model.best_estimator_.estimate_population_outcome(data['X'], data['a'], data['y'])
+        pd.testing.assert_series_equal(
+            grid_model.best_estimator_.estimate_population_outcome(data['X'], data['a'], data['y']),
+            grid_model.estimate_population_outcome(data['X'], data['a'], data['y'])
+        )
+
+        with self.subTest("Grid model has its inner estimator's methods that work as expected"):
+            propensities = grid_model.compute_propensity(data['X'], data['a'])
+            self.assertLessEqual(0.2, propensities.min())
+
+            weights = grid_model.compute_weights(data['X'], data['a'])
+            self.assertIsInstance(weights, pd.Series)
+            weights = grid_model.compute_weight_matrix(data['X'], data['a'])
+            self.assertIsInstance(weights, pd.DataFrame)
+
+    def test_single_outcome_scorer(self):
+        data = self.data
+        model = StratifiedStandardization(GradientBoostingRegressor())
+        # Can handle the `learner` being a dict because before `fit` it is not a dict, but a single model type
+        scorer = get_scorer("balanced_residuals_error")
+        grid_model = self._fit_search_model(model, scorer, dict(learner__n_estimators=[10, 20]))
+
+        self.assertIsInstance(grid_model.best_estimator_, model.__class__)
+        pd.testing.assert_series_equal(
+            grid_model.best_estimator_.estimate_population_outcome(data['X'], data['a'], data['y']),
+            grid_model.estimate_population_outcome(data['X'], data['a'], data['y'])
+        )
+
+        with self.subTest("Estimator behaves as inner estimator"):
+            ind_outcomes = grid_model.estimate_individual_outcome(data['X'], data['a'])
+            self.assertEqual(data['X'].shape[0], ind_outcomes.shape[0])
+            self.assertEqual(2, ind_outcomes.shape[1])
+
+    # @unittest.expectedFailure
+    def test_different_stratified_estimators(self):
+        """Should fail because can't assign the params once the `learner` is a dictionary."""
+        data = self.data
+        model = StratifiedStandardization({
+            0: GradientBoostingRegressor(), 1: LinearRegression(),
+        })
+        scorer = get_scorer("balanced_residuals_error")
+        with self.assertRaises(AttributeError):
+            grid_model = self._fit_search_model(model, scorer, dict(learner__n_estimators=[10, 20]))
+        # self.assertIsInstance(grid_model.best_estimator_, model.__class__)
+        # grid_model.best_estimator_.estimate_population_outcome(data['X'], data['a'], data['y'])
+
+    def test_single_propensity_scorer_name(self):
+        data = self.data
+        model = IPW(LogisticRegression(penalty="none", solver="saga", max_iter=10000))
+        grid_model = self._fit_search_model(model, "weighted_roc_auc_error", dict(clip_min=[0.2, 0.3]))
+
+        self.assertIsInstance(grid_model.best_estimator_, model.__class__)
+        grid_model.best_estimator_.estimate_population_outcome(data['X'], data['a'], data['y'])
+        pd.testing.assert_series_equal(
+            grid_model.best_estimator_.estimate_population_outcome(data['X'], data['a'], data['y']),
+            grid_model.estimate_population_outcome(data['X'], data['a'], data['y'])
+        )
+
+    def test_multiple_scorers(self):
+        data = self.data
+        model = IPW(LogisticRegression(penalty="none", solver="saga", max_iter=10000, random_state=0))
+        scorers_dict = {
+            "weighted_roc_auc_error": get_scorer("weighted_roc_auc_error"),
+            "covariate_balancing_error": get_scorer("covariate_balancing_error"),
+        }
+        scorers_list = ["weighted_roc_auc_error", "covariate_balancing_error"]
+        scorers_tuple = ("weighted_roc_auc_error", "covariate_balancing_error")
+        grid_model_dict = self._fit_search_model(
+            model, scorers_dict,
+            dict(clip_min=[0.05, 0.2]),
+            refit="weighted_roc_auc_error",
+        )
+        grid_model_list = self._fit_search_model(
+            model, scorers_list,
+            dict(clip_min=[0.05, 0.2]),
+            refit="weighted_roc_auc_error"
+        )
+        grid_model_tuple = self._fit_search_model(
+            model, scorers_tuple,
+            dict(clip_min=[0.05, 0.2]),
+            refit="weighted_roc_auc_error"
+        )
+
+        # dict with list
+        self.assertEqual(
+            grid_model_dict.best_estimator_.clip_min,
+            grid_model_list.best_estimator_.clip_min,
+        )
+        np.testing.assert_array_almost_equal(
+            grid_model_dict.best_estimator_.learner.coef_,
+            grid_model_list.best_estimator_.learner.coef_,
+        )
+        pd.testing.assert_series_equal(
+            grid_model_dict.estimate_population_outcome(data['X'], data['a'], data['y']),
+            grid_model_list.estimate_population_outcome(data['X'], data['a'], data['y']),
+            check_exact=False,
+        )
+        # tuple with list
+        self.assertEqual(
+            grid_model_tuple.best_estimator_.clip_min,
+            grid_model_list.best_estimator_.clip_min,
+        )
+        np.testing.assert_array_almost_equal(
+            grid_model_tuple.best_estimator_.learner.coef_,
+            grid_model_list.best_estimator_.learner.coef_,
+        )
+        pd.testing.assert_series_equal(
+            grid_model_tuple.estimate_population_outcome(data['X'], data['a'], data['y']),
+            grid_model_list.estimate_population_outcome(data['X'], data['a'], data['y']),
+            check_exact=False,
+        )
+
+    def test_bad_scorer(self):
+        model = IPW(LogisticRegression(penalty="none", solver="saga", max_iter=10000))
+        CausalGridSearchCV = causalize_searcher(GridSearchCV)
+        with self.assertRaises(ValueError):
+            grid_model = CausalGridSearchCV(
+                model,
+                param_grid=dict(clip_min=[0.2, 0.3]),
+                scoring=3,
+            )
+
+    def test_doubly_robust(self):
+        data = self.data
+        CausalGridSearchCV = causalize_searcher(GridSearchCV)
+
+        ipw = IPW(LogisticRegression(penalty="none", solver="saga", max_iter=10000))
+        ipw_grid_model = CausalGridSearchCV(
+            ipw,
+            param_grid=dict(clip_min=[0.2, 0.3]), cv=2,
+            scoring=get_scorer("weighted_roc_auc_error"),
+        )
+
+        std = Standardization(GradientBoostingRegressor())
+        CausalGridSearchCV = causalize_searcher(GridSearchCV)
+        std_grid_model = CausalGridSearchCV(
+            std,
+            param_grid=dict(learner__n_estimators=[10, 20]), cv=3,
+            scoring=get_scorer("balanced_residuals_error"),
+        )
+
+        model = AIPW(
+            outcome_model=std_grid_model,
+            weight_model=ipw_grid_model,
+        )
+
+        model.fit(data['X'], data['a'], data['y'])
+        propensities = model.weight_model.compute_propensity(data['X'], data['a'])
+        self.assertLessEqual(0.2, propensities.min())
+        model.estimate_population_outcome(data['X'], data['a'], data['y'])
+        pd.testing.assert_frame_equal(
+            model.estimate_individual_outcome(data['X'], data['a']),
+            model.outcome_model.estimate_individual_outcome(data['X'], data['a'])
+            # AIPW's individual outcome is the internal standardization individual outcome
+        )
+
+    def test_selecting_different_core_estimators(self):
+        from sklearn.dummy import DummyClassifier
+        data = self.data
+        model = IPW(DummyClassifier())  # DummyClassifier used just for initialization
+        scorer = get_scorer("weighted_roc_auc_error")
+        param_grid = dict(
+            learner=[
+                LogisticRegression(penalty="none", solver="saga", max_iter=10000, random_state=0),
+                LogisticRegression(penalty="l1", solver="saga", max_iter=10000, random_state=0),
+                LogisticRegression(penalty="l2", solver="saga", max_iter=10000, random_state=0),
+                GradientBoostingClassifier(random_state=0),
+            ]
+        )
+        grid_model = self._fit_search_model(
+            model,
+            scorer,
+            param_grid
+        )
+
+        self.assertIsInstance(grid_model.best_estimator_, model.__class__)
+        self.assertNotIsInstance(grid_model.best_estimator_, DummyClassifier)
+        self.assertIsInstance(grid_model.best_estimator_.learner, LogisticRegression)  # Best base estimator
+        outcomes = grid_model.best_estimator_.estimate_population_outcome(data['X'], data['a'], data['y'])
+        self.assertIsInstance(outcomes, pd.Series)
+
+    def test_different_search_algorithm(self):
+        from causallib.model_selection import RandomizedSearchCV
+        from scipy.stats import uniform
+
+        data = self.data
+        ipw = IPW(LogisticRegression(penalty="none", solver="saga", max_iter=10000))
+        model = RandomizedSearchCV(
+            ipw,
+            param_distributions=dict(clip_min=uniform(loc=0, scale=0.5)), cv=2,
+            scoring=get_scorer("weighted_roc_auc_error"),
+        )
+        model.fit(data['X'], data['a'], data['y'])
+        self.assertIsInstance(model.best_estimator_, ipw.__class__)
+        model.best_estimator_.estimate_population_outcome(data['X'], data['a'], data['y'])
+        pd.testing.assert_series_equal(
+            model.best_estimator_.estimate_population_outcome(data['X'], data['a'], data['y']),
+            model.estimate_population_outcome(data['X'], data['a'], data['y'])
+        )
+
+    def test_with_custom_kfold(self):
+        from causallib.model_selection import TreatmentOutcomeStratifiedKFold
+        from causallib.model_selection import TreatmentStratifiedKFold
+
+        data = self.data
+        y = np.random.binomial(2, 0.5, size=data['y'].shape[0])  # binary y, for doubly stratification
+        y = pd.Series(y, index=data['y'].index)
+        model = IPW(LogisticRegression(penalty="none", solver="saga", max_iter=10000))
+        scorer = get_scorer("weighted_roc_auc_error")
+
+        with self.subTest("Doubly Stratified K-fold"):
+            cv = TreatmentOutcomeStratifiedKFold(n_splits=2)
+            treatment_outcome_grid_model = self._fit_search_model(
+                model, scorer,
+                dict(clip_min=[0.2, 0.3]),
+                cv=cv,
+                data={**data, "y": y},
+            )
+            outcomes = treatment_outcome_grid_model.estimate_population_outcome(data['X'], data['a'], data['y'])
+            self.assertIsInstance(outcomes, pd.Series)
+
+        with self.subTest("Treatment-stratified k-fold"):
+            cv = TreatmentStratifiedKFold(n_splits=2)
+            treatment_grid_model = self._fit_search_model(
+                model, scorer,
+                dict(clip_min=[0.2, 0.3]),
+                cv=cv,
+                data={**data, "y": y},
+            )
+            outcomes = treatment_grid_model.estimate_population_outcome(data['X'], data['a'], data['y'])
+            self.assertIsInstance(outcomes, pd.Series)

--- a/causallib/tests/test_split.py
+++ b/causallib/tests/test_split.py
@@ -1,0 +1,161 @@
+import unittest
+import pandas as pd
+
+from causallib.model_selection import TreatmentOutcomeStratifiedKFold
+from causallib.model_selection import TreatmentStratifiedKFold
+
+
+class TestTreatmentOutcomeStratifiedKFold(unittest.TestCase):
+    def test_binary_splits(self):
+        X = pd.DataFrame({0: [10] * 8})  # Dummy corresponding X
+        a = pd.Series([0, 0, 0, 0, 1, 1, 1, 1])
+        y = pd.Series([0, 0, 1, 1, 0, 0, 1, 1])
+        kfold = TreatmentOutcomeStratifiedKFold(n_splits=2)
+        folds = list(kfold._split(X, a, y))[0]  # 2 folds, so first element suffices
+
+        self.assertListEqual(
+            list(folds[0]), [1, 3, 5, 7],
+        )
+        self.assertListEqual(
+            list(folds[1]), [0, 2, 4, 6],
+        )
+
+        labels = kfold._combine_treatment_outcome_labels(a, y)
+        self.assertListEqual(
+            list(labels),
+            [0, 0, 1, 1, 2, 2, 3, 3],
+        )
+
+    def ensure_multiclass_splits(self, X, a, y):
+        kfold = TreatmentOutcomeStratifiedKFold(n_splits=2)
+        folds = list(kfold._split(X, a, y))[0]  # 2 folds, so first element suffices
+
+        self.assertListEqual(
+            list(folds[0]),  # Train indices
+            [1, 3, 5, 7, 9, 11]
+        )
+        self.assertListEqual(
+            list(folds[1]),  # Train indices
+            [0, 2, 4, 6, 8, 10]
+        )
+
+    def test_multi_outcome_splits(self):
+        X = pd.DataFrame({0: [10] * 12})  # Dummy corresponding X
+        a = pd.Series([0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1])
+        y = pd.Series([0, 0, 1, 1, 2, 2, 0, 0, 1, 1, 2, 2])
+        self.ensure_multiclass_splits(X, a, y)
+
+        labels = TreatmentOutcomeStratifiedKFold._combine_treatment_outcome_labels(a, y)
+        self.assertListEqual(
+            list(labels),
+            [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5],
+        )
+
+    def test_multi_treatment_splits(self):
+        X = pd.DataFrame({0: [10] * 12})  # Dummy corresponding X
+        a = pd.Series([0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2])
+        y = pd.Series([0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1])
+        self.ensure_multiclass_splits(X, a, y)
+
+        labels = TreatmentOutcomeStratifiedKFold._combine_treatment_outcome_labels(a, y)
+        self.assertListEqual(
+            list(labels),
+            [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5],
+        )
+
+    def test_continuous_outcome(self):
+        X = pd.DataFrame({0: [10] * 4})  # Dummy corresponding X
+        a = pd.Series([0, 0, 1, 1])
+        y = pd.Series([42.0, 42.1, 42.2, 42.3])
+        kfold = TreatmentOutcomeStratifiedKFold(n_splits=2, shuffle=False)
+        with self.assertRaises(ValueError):
+            kfold._split(X, a, y)
+
+    def test_sklearn_search_compatibility(self):
+        X = pd.DataFrame({0: [10] * 8})  # Dummy corresponding X
+        a = pd.Series([0, 0, 0, 0, 1, 1, 1, 1])
+        y = pd.Series([0, 0, 1, 1, 0, 0, 1, 1])
+        Xa = X.join(a.to_frame("a"))
+        kfold = TreatmentOutcomeStratifiedKFold(n_splits=2)
+        folds = list(kfold.split(Xa, y))[0]  # 2 folds, so first element suffices
+
+        self.assertListEqual(
+            list(folds[0]), [1, 3, 5, 7],
+        )
+        self.assertListEqual(
+            list(folds[1]), [0, 2, 4, 6],
+        )
+
+
+class TestTreatmentStratifiedKFold(unittest.TestCase):
+    def test_binary_splits(self):
+        X = pd.DataFrame({0: [10] * 8})  # Dummy corresponding X
+        a = pd.Series([0, 0, 0, 0, 1, 1, 1, 1])
+        y = pd.Series([0, 0, 1, 1, 0, 0, 1, 1])  # should be ignored
+        kfold = TreatmentStratifiedKFold(n_splits=2)
+        folds = list(kfold._split(X, a, y))[1]  # 2 folds, so first element suffices
+
+        self.assertListEqual(
+            list(folds[0]), [0, 1, 4, 5],
+        )
+        self.assertListEqual(
+            list(folds[1]), [2, 3, 6, 7],
+        )
+
+    def test_with_no_outcome(self):
+        X = pd.DataFrame({0: [10] * 8})  # Dummy corresponding X
+        a = pd.Series([0, 0, 0, 0, 1, 1, 1, 1])
+        Xa = X.join(a.to_frame("a"))
+        kfold = TreatmentStratifiedKFold(n_splits=2)
+        folds = list(kfold.split(Xa))[1]
+
+        self.assertListEqual(list(folds[0]), [0, 1, 4, 5])
+        self.assertListEqual(list(folds[1]), [2, 3, 6, 7])
+
+    def test_multiclass_splits(self):
+        X = pd.DataFrame({0: [10] * 12})  # Dummy corresponding X
+        a = pd.Series([0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2])
+        y = pd.Series([0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1])
+        kfold = TreatmentStratifiedKFold(n_splits=2)
+        folds = list(kfold._split(X, a, y))[1]  # 2 folds, so first element suffices
+
+        self.assertListEqual(
+            list(folds[0]), [0, 1, 4, 5, 8, 9],
+        )
+        self.assertListEqual(
+            list(folds[1]), [2, 3, 6, 7, 10, 11],
+        )
+
+    def test_against_sklearn_stratified_kfold(self):
+        from sklearn.model_selection import StratifiedKFold
+
+        X = pd.DataFrame({0: [10] * 4})
+        a = pd.Series([0, 0, 1, 1])
+        y = pd.Series([42.0, 42.1, 42.2, 42.3])
+
+        kfold = TreatmentStratifiedKFold(n_splits=2, shuffle=False)
+        folds = list(kfold._split(X, a, y))[0]  # 2 folds, so first element suffices
+
+        sklearn_kfold = StratifiedKFold(n_splits=2, shuffle=False)
+        sklearn_folds = list(sklearn_kfold.split(X, a))[0]  # 2 folds, so first element suffices
+        self.assertListEqual(
+            folds[0].tolist(), sklearn_folds[0].tolist()
+        )
+        self.assertListEqual(
+            folds[1].tolist(), sklearn_folds[1].tolist()
+        )
+
+    def test_sklearn_search_compatibility(self):
+        X = pd.DataFrame({0: [10] * 8})
+        a = pd.Series([0, 0, 0, 0, 1, 1, 1, 1])
+        y = pd.Series([0, 0, 1, 1, 0, 0, 1, 1])
+        Xa = X.join(a.to_frame("a"))
+        kfold = TreatmentStratifiedKFold(n_splits=2)
+        folds = list(kfold.split(Xa, y))[1]
+
+        self.assertListEqual(
+            list(folds[0]), [0, 1, 4, 5],
+        )
+        self.assertListEqual(
+            list(folds[1]), [2, 3, 6, 7],
+        )

--- a/causallib/tests/test_standardization.py
+++ b/causallib/tests/test_standardization.py
@@ -180,6 +180,9 @@ class TestStandardizationStratified(TestStandardizationCommon):
         with self.subTest("Test no-treatment initialization after fit"):
             self.assertIsInstance(estimator.learner, dict)
             self.assertSetEqual(set(estimator.learner.keys()), set(self.data_lin["a"]))
+        with self.subTest("Test treatment values were added"):
+            self.assertIsNone(estimator.treatment_values)  # No treatment values in initiation
+            self.assertListEqual([0, 1], estimator.treatment_values_)  # Treatment values added after fit
 
     def test_initialization_with_dict_of_learners(self):
         learners = {0: LinearRegression(normalize=False),

--- a/causallib/utils/general_tools.py
+++ b/causallib/utils/general_tools.py
@@ -60,7 +60,7 @@ def create_repr_string(o):
     # Filter peripheral unimportant attribute names:
     params = [
         attr for attr in dir(o) if not attr.startswith('__')  # Data-model dunder methods
-                                   and not callable(getattr(o, attr))  # Remove other methods, keep only fields
+                                   and not callable(getattr(o, attr, None))  # Remove other methods, keep only fields
                                    and not attr.startswith("_abc")  # Remove abstract-related attributes
                                    and not attr.endswith("_")  # Remove attributes stated after initialization
                                    and not attr == "CALCULATE_EFFECT"  # Remove the EffectEstimator attribute


### PR DESCRIPTION
Adds the ability to perform model selection on causal models using cross validation.
The general idea is to utilize scikit-learn's already established framework for model selection using cross validation with metrics/scorers and extends it to causallib's use. 

This PR has three main additions:
1. Causal metrics and scorers.
    Mainly, taking some of the graphical metrics described [_Shimoni et al. 2019_](https://arxiv.org/abs/1906.00442) and are available in `evaluation` module in this package, and quantifying them so they could be used for automated scoring (for example, post-weighting ROC AUC should be as close to the chance AUC of 0.5). 
     Coding these as metrics and also providing them with a scikit-learn scorer API (available in the `get_scorers()` function). 

2. Hyperparameter search models.
    A causallib version of `GridSearchCV` and `RandomizedSearchCV` that is fully compatible with causallib's API. 
    But also a way to dynamically wrap any other scikit-learn-compatible search models and make them causallib-compatible with the `causalize_searcher()` function.

3. K-fold objects for cross validation
    Specifically, objects to create stratified folds based on either the treatment or both the treatment and outcome (applicable if outcome type is of classes). 

Tying it all together, we can auto-tune causal models, as such:
```python
from causallib.model_selection import GridSearchCV
from causallib.model_selection import TreatmentStratifiedKFold
from causallib.datasets import load_nhefs
from causallib.estimation import IPW
from sklearn.linear_model import LogisticRegression

data = load_nhefs()
ipw = IPW(LogisticRegression())
cv = TreatmentStratifiedKFold(n_splits=10)
param_grid = dict(
    clip_min=[0.01, 0.1],  # IPW hyperparameters
    learner__C=[0.001, 0.01, 0.1],  # LogisticRegrssion hyperparameters
)

grid_model = GridSearchCV(
    ipw,
    param_grid=param_grid,
    scoring="weighted_roc_auc_error",  # A scorer for IPW
    cv=cv,
)
grid_model.fit(data.X, data.a, data.y)
potential_outcomes = grid_model.estimate_population_outcome(data.X, data.a, data.y)
```

Thanks to @mmdanziger for reviewing